### PR TITLE
Use RPATH on OS/X

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -63,6 +63,11 @@ endfunction()
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(QTE_ENABLE_PYTHON "Enable qtExtensions Python (PySide) bindings" OFF)
 
+# Use RPATH on OS/X
+if(APPLE)
+  set(CMAKE_MACOSX_RPATH TRUE)
+endif()
+
 # Set compiler flags for exports (e.g. -fvisibility=hidden)
 add_compiler_export_flags()
 


### PR DESCRIPTION
Turn on RPATH's on OS/X unconditionally. This should give more UNIX-like behavior as far as libraries that Just Work, path-wise, from a build directory. More to the point, it silences a warning when using newer versions of CMake which default to this behavior. (We could also bump the minimum required CMake version, but we like backward compatibility, and for now, this doesn't seem like sufficient reason to start requiring 3.x.)