### PR TITLE
Set environment when running qte-amc

### DIFF
--- a/cmake/modules/UseQtExtensions.cmake
+++ b/cmake/modules/UseQtExtensions.cmake
@@ -13,9 +13,27 @@ function(qte_amc_wrap_ui outvar name)
   endforeach()
   set(outfile "${CMAKE_CURRENT_BINARY_DIR}/${name}.h")
   set_source_files_properties(${outfiles} ${outfile} PROPERTIES GENERATED TRUE)
-  set(QTE_AMC_EXECUTABLE qte-amc) # TODO need a launcher on WIN32 to set PATH
+
+  if (NOT CMAKE_VERSION VERSION_LESS 3.1)
+    if (WIN32)
+      if(NOT DEFINED QT_QMAKE_EXECUTABLE)
+        message(FATAL_ERROR "Qt must be found before using qte_amc_wrap_ui")
+      endif()
+      get_filename_component(QT_BIN_DIR "${QT_QMAKE_EXECUTABLE}" DIRECTORY)
+
+      set(QTE_AMC_ENVIRONMENT
+        ${CMAKE_COMMAND} -E env "\"PATH=${QT_BIN_DIR}\\;%PATH%\"")
+    else()
+      # TODO need to set library path?
+      set(QTE_AMC_ENVIRONMENT)
+    endif()
+  endif()
+
+  set(QTE_AMC_EXECUTABLE $<TARGET_FILE:qte-amc>)
+
   add_custom_command(OUTPUT ${outfiles} ${outfile}
-    COMMAND ${QTE_AMC_EXECUTABLE} ${outfile} ${infiles}
+    COMMAND ${QTE_AMC_ENVIRONMENT}
+            ${QTE_AMC_EXECUTABLE} ${outfile} ${infiles}
     DEPENDS ${QTE_AMC_EXECUTABLE} ${infiles})
   set(${outvar} ${outfiles} ${outfile} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
Modify `qte_amc_wrap_ui` to set the environment (`PATH`, specifically) when running `qte-amc` on Windows, when sufficiently new CMake is used. This should make it easier to build, since running `qte-amc`, which is normally done at build time by projects using it, requires that the Qt libraries are in the library path.