### PR TITLE
Wrap qte-amc for a custom environment on OS X

### DIFF
--- a/cmake/modules/UseQtExtensions.cmake
+++ b/cmake/modules/UseQtExtensions.cmake
@@ -24,10 +24,10 @@ function(qte_amc_wrap_ui outvar name)
       set(QTE_AMC_ENVIRONMENT
         ${CMAKE_COMMAND} -E env "\"PATH=${QT_BIN_DIR}\\;%PATH%\"")
     elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
-      if(NOT DEFINED QT_QTGUI_LIBRARY)
+      if(NOT DEFINED QT_QTCORE_LIBRARY)
         message(FATAL_ERROR "Qt must be found before using qte_amc_wrap_ui")
       endif()
-      get_filename_component(QT_LIB_DIR "${QT_QTGUI_LIBRARY}" DIRECTORY)
+      get_filename_component(QT_LIB_DIR "${QT_QTCORE_LIBRARY}" DIRECTORY)
 
       set(QTE_AMC_ENVIRONMENT
         ${CMAKE_COMMAND} -E env "\"DYLD_FALLBACK_LIBRARY_PATH=${QT_LIB_DIR}:\${DYLD_FALLBACK_LIBRARY_PATH}\"")

--- a/cmake/modules/UseQtExtensions.cmake
+++ b/cmake/modules/UseQtExtensions.cmake
@@ -23,6 +23,14 @@ function(qte_amc_wrap_ui outvar name)
 
       set(QTE_AMC_ENVIRONMENT
         ${CMAKE_COMMAND} -E env "\"PATH=${QT_BIN_DIR}\\;%PATH%\"")
+    elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+      if(NOT DEFINED QT_QTGUI_LIBRARY)
+        message(FATAL_ERROR "Qt must be found before using qte_amc_wrap_ui")
+      endif()
+      get_filename_component(QT_LIB_DIR "${QT_QTGUI_LIBRARY}" DIRECTORY)
+
+      set(QTE_AMC_ENVIRONMENT
+        ${CMAKE_COMMAND} -E env "\"DYLD_FALLBACK_LIBRARY_PATH=${QT_LIB_DIR}:\${DYLD_FALLBACK_LIBRARY_PATH}\"")
     else()
       # TODO need to set library path?
       set(QTE_AMC_ENVIRONMENT)

--- a/cmake/modules/UseQtExtensions.cmake
+++ b/cmake/modules/UseQtExtensions.cmake
@@ -23,7 +23,7 @@ function(qte_amc_wrap_ui outvar name)
 
       set(QTE_AMC_ENVIRONMENT
         ${CMAKE_COMMAND} -E env "\"PATH=${QT_BIN_DIR}\\;%PATH%\"")
-    elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+    elseif (APPLE)
       if(NOT DEFINED QT_QTCORE_LIBRARY)
         message(FATAL_ERROR "Qt must be found before using qte_amc_wrap_ui")
       endif()


### PR DESCRIPTION
OS X has a similar problem to Windows in that Qt or its dependencies may
not be found when running qte-amc.  Generally this can be fixed by
setting DYLD_FALLBACK_LIBRARY_PATH.  The problem arises on OS X 10.11
(El Capitan) and above in which the system integrity protection feature
clears the DYLD_* environment variables.  This patch uses a similar
trick already applied for Windows to set the environment before calling
qte-amc.