### PR TITLE
Add theming support helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ set(qtExtensionsSources
     util/qtActionFactory.cpp
     util/qtActionManager.cpp
     util/qtActionPriorityList.cpp
+    util/qtColorScheme.cpp
     util/qtColorUtil.cpp
     util/qtDockController.cpp
     util/qtDockControllerPrivate.cpp
@@ -147,6 +148,7 @@ set(qtExtensionsInstallHeaders
     util/qtAbstractSetting.h
     util/qtActionFactory.h
     util/qtActionManager.h
+    util/qtColorScheme.h
     util/qtColorUtil.h
     util/qtDockController.h
     util/qtGradient.h

--- a/util/qtColorScheme.cpp
+++ b/util/qtColorScheme.cpp
@@ -48,11 +48,11 @@ void qtColorScheme::load(QPalette::ColorGroup group, const QString& groupName,
                          QPalette::ColorRole role, const QString& roleName,
                          const QSettings& settings)
 {
-  auto const& defaultColor = this->color(group, role);
-
-  auto const& colorName = settings.value(
-    this->key(groupName, roleName), defaultColor).toString();
-  this->setColor(group, role, QColor{colorName});
+  auto const& color = settings.value(this->key(groupName, roleName));
+  if (color.isValid())
+    {
+    this->setColor(group, role, QColor{color.toString()});
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/util/qtColorScheme.cpp
+++ b/util/qtColorScheme.cpp
@@ -1,0 +1,107 @@
+/*ckwg +5
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#include "qtColorScheme.h"
+
+#include <QSettings>
+
+#define ARGS(x) QPalette::x, #x
+
+//-----------------------------------------------------------------------------
+qtColorScheme::qtColorScheme()
+{
+}
+
+//-----------------------------------------------------------------------------
+void qtColorScheme::load(const QSettings& settings)
+{
+  this->load(ARGS(Active), settings);
+  this->load(ARGS(Inactive), settings);
+  this->load(ARGS(Disabled), settings);
+}
+
+//-----------------------------------------------------------------------------
+void qtColorScheme::load(QPalette::ColorGroup group, const QString& groupName,
+                         QSettings const& settings)
+{
+  this->load(group, groupName, ARGS(Base), settings);
+  this->load(group, groupName, ARGS(Text), settings);
+  this->load(group, groupName, ARGS(AlternateBase), settings);
+  this->load(group, groupName, ARGS(Window), settings);
+  this->load(group, groupName, ARGS(WindowText), settings);
+  this->load(group, groupName, ARGS(Button), settings);
+  this->load(group, groupName, ARGS(ButtonText), settings);
+  this->load(group, groupName, ARGS(Highlight), settings);
+  this->load(group, groupName, ARGS(HighlightedText), settings);
+  this->load(group, groupName, ARGS(ToolTipBase), settings);
+  this->load(group, groupName, ARGS(ToolTipText), settings);
+  this->load(group, groupName, ARGS(Link), settings);
+  this->load(group, groupName, ARGS(LinkVisited), settings);
+  this->load(group, groupName, ARGS(BrightText), settings);
+}
+
+//-----------------------------------------------------------------------------
+void qtColorScheme::load(QPalette::ColorGroup group, const QString& groupName,
+                         QPalette::ColorRole role, const QString& roleName,
+                         const QSettings& settings)
+{
+  auto const& defaultColor = this->color(group, role);
+
+  auto const& colorName = settings.value(
+    this->key(groupName, roleName), defaultColor).toString();
+  this->setColor(group, role, QColor{colorName});
+}
+
+//-----------------------------------------------------------------------------
+void qtColorScheme::save(QSettings& settings) const
+{
+  this->save(ARGS(Active), settings);
+  this->save(ARGS(Inactive), settings);
+  this->save(ARGS(Disabled), settings);
+}
+
+//-----------------------------------------------------------------------------
+void qtColorScheme::save(QPalette::ColorGroup group, const QString& groupName,
+                         QSettings& settings) const
+{
+  this->save(group, groupName, ARGS(Base), settings);
+  this->save(group, groupName, ARGS(Text), settings);
+  this->save(group, groupName, ARGS(AlternateBase), settings);
+  this->save(group, groupName, ARGS(Window), settings);
+  this->save(group, groupName, ARGS(WindowText), settings);
+  this->save(group, groupName, ARGS(Button), settings);
+  this->save(group, groupName, ARGS(ButtonText), settings);
+  this->save(group, groupName, ARGS(Highlight), settings);
+  this->save(group, groupName, ARGS(HighlightedText), settings);
+  this->save(group, groupName, ARGS(ToolTipBase), settings);
+  this->save(group, groupName, ARGS(ToolTipText), settings);
+  this->save(group, groupName, ARGS(Link), settings);
+  this->save(group, groupName, ARGS(LinkVisited), settings);
+  this->save(group, groupName, ARGS(BrightText), settings);
+}
+
+//-----------------------------------------------------------------------------
+void qtColorScheme::save(QPalette::ColorGroup group, const QString& groupName,
+                         QPalette::ColorRole role, const QString& roleName,
+                         QSettings& settings) const
+{
+  settings.setValue(this->key(groupName, roleName),
+                    this->color(group, role).name());
+}
+
+//-----------------------------------------------------------------------------
+QString qtColorScheme::key(const QString& group, const QString& role) const
+{
+  return QString{"%1/%2"}.arg(group, role);
+}
+
+//-----------------------------------------------------------------------------
+qtColorScheme qtColorScheme::fromSettings(const QSettings& settings)
+{
+  qtColorScheme scheme;
+  scheme.load(settings);
+  return scheme;
+}

--- a/util/qtColorScheme.h
+++ b/util/qtColorScheme.h
@@ -1,0 +1,45 @@
+/*ckwg +5
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#ifndef __qtColorScheme_h
+#define __qtColorScheme_h
+
+#include <QPalette>
+
+#include "../core/qtGlobal.h"
+
+class QSettings;
+
+class QTE_EXPORT qtColorScheme : public QPalette
+{
+public:
+  qtColorScheme();
+  qtColorScheme(const QPalette& other) : QPalette(other) {}
+
+  qtColorScheme& operator=(const QPalette& other)
+  { this->QPalette::operator=(other); return *this; }
+
+  void load(const QSettings&);
+  void save(QSettings&) const;
+
+  static qtColorScheme fromSettings(const QSettings&);
+
+protected:
+  void load(QPalette::ColorGroup, const QString& group, const QSettings&);
+  void save(QPalette::ColorGroup, const QString& group, QSettings&) const;
+
+  void load(QPalette::ColorGroup, const QString& group,
+            QPalette::ColorRole, const QString& role,
+            const QSettings&);
+
+  void save(QPalette::ColorGroup, const QString& group,
+            QPalette::ColorRole, const QString& role,
+            QSettings&) const;
+
+  QString key(const QString& group, const QString& role) const;
+};
+
+#endif


### PR DESCRIPTION
Create new class `qtColorScheme`, which is useful for assisting consumers with implementing theming support (i.e. the ability to load a custom color scheme from a file).