### PR TITLE
Fix broken qtGet overload resolution on GCC 4.8

### DIFF
--- a/core/qtGet.h
+++ b/core/qtGet.h
@@ -41,7 +41,17 @@ auto qtGet(Container& c, Key const& key)
 }
 
 //-----------------------------------------------------------------------------
+#if !(__GNUC__ == 4 && __GNUC_MINOR__ < 9)
+// This explicitly deleted overload exists to prevent users from calling qtGet
+// on a temporary value, which would lead to a dangling reference.
+// Unfortunately, GCC 4.8 has a bug in overload resolution related to r-value
+// references, which causes use of qtGet to be ambiguous if this overload is
+// present. Since it exists only to prevent users from using the function in a
+// broken manner, it isn't necessary for correct use, so just omit it when
+// compiling with GCC 4.8. Correct code will still work; users of GCC 4.8 will
+// just lose out on incorrect code being caught as an error.
 template <typename Container, typename Key>
 void qtGet(Container&& c, Key const& key) = delete;
+#endif
 
 #endif


### PR DESCRIPTION
Exclude safety overload when building on GCC 4.8, which has broken overload resolution in the face of r-value references.

There are three overloads of `qtGet`; one each for `const` and non-`const` references, and a safety overload for temporaries, which is explicitly deleted in order to prevent users calling `qtGet` on a temporary, which would lead to a dangling reference. Unfortunately, the latter confuses the broken overload resolution in GCC 4.8 (GCC 4.9 and later do not have this bug). However, since it is only a safety mechanism to prevent users from doing something wrong, it is not called by correct code. Thus, it is feasible to omit this overload when building with GCC 4.8; such users will just lose out on being prevented from writing broken code.