### PR TITLE
Implement natural sorting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ set(qtExtensionsSources
     util/qtDockControllerPrivate.cpp
     util/qtGradient.cpp
     util/qtJson.cpp
+    util/qtNaturalSort.cpp
     util/qtPrioritizedMenuProxy.cpp
     util/qtPrioritizedToolBarProxy.cpp
     util/qtProcess.cpp
@@ -157,6 +158,7 @@ set(qtExtensionsInstallHeaders
     util/qtDockController.h
     util/qtGradient.h
     util/qtJson.h
+    util/qtNaturalSort.h
     util/qtPrioritizedMenuProxy.h
     util/qtPrioritizedToolBarProxy.h
     util/qtProcess.h

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,8 +25,8 @@ qte_add_test(testColorButton        INTERACTIVE TestColorButton.cpp)
 qte_add_test(testConfirmationDialog INTERACTIVE TestConfirmationDialog.cpp)
 qte_add_test(testGradientEditor     INTERACTIVE TestGradientEditor.cpp)
 qte_add_test(testGradientWidget     INTERACTIVE TestGradientWidget.cpp)
-qte_add_test(testThrobber           INTERACTIVE TestThrobber.cpp)
 qte_add_test(testProgressWidget     INTERACTIVE TestProgressWidget.cpp)
+qte_add_test(testThrobber           INTERACTIVE TestThrobber.cpp)
 
 # Automated tests
 qte_add_test(qtExtensions-Kst testKst
@@ -34,4 +34,5 @@ qte_add_test(qtExtensions-Kst testKst
              ARGS ${CMAKE_CURRENT_SOURCE_DIR}/testdata.kst
 )
 
-qte_add_test(qtExtensions-UiState testUiState TestUiState.cpp)
+qte_add_test(qtExtensions-NaturalSort testNaturalSort TestNaturalSort.cpp)
+qte_add_test(qtExtensions-UiState     testUiState     TestUiState.cpp)

--- a/tests/TestNaturalSort.cpp
+++ b/tests/TestNaturalSort.cpp
@@ -1,0 +1,184 @@
+/*ckwg +5
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#define TEST_OBJECT_NAME t_obj
+
+#include "../core/qtTest.h"
+#include "../util/qtNaturalSort.h"
+
+#include <QDebug>
+#include <QTextCodec>
+
+using namespace qtNaturalSort;
+
+// U+1D7FB mathematical monospace digit '5'
+static auto const& special5 = QString::fromUtf8(u8"\xf0\x9d\x9f\xbb");
+
+//-----------------------------------------------------------------------------
+struct ExpectedStringGroup
+{
+    ExpectedStringGroup() = default;
+    ExpectedStringGroup(ExpectedStringGroup const&) = default;
+
+    ExpectedStringGroup(QString const& c, int l = 0, int s = 0)
+        : characters{c}, leadingZeros{l}, significantDigits{s}
+    {}
+
+    ExpectedStringGroup(StringGroup const& g)
+        : characters{g.characters.toString()},
+          leadingZeros{g.leadingZeros},
+          significantDigits{g.significantDigits}
+    {}
+
+    bool operator==(ExpectedStringGroup const& other)
+    {
+        return characters == other.characters &&
+               leadingZeros == other.leadingZeros &&
+               significantDigits == other.significantDigits;
+    }
+
+    QString const characters;
+    int const leadingZeros = 0;
+    int const significantDigits = 0;
+};
+
+//-----------------------------------------------------------------------------
+QDebug& operator<<(QDebug& dbg, ExpectedStringGroup g)
+{
+  dbg << '{' << g.characters;
+  if (g.significantDigits || g.leadingZeros)
+    dbg << ", " << g.leadingZeros << ", " << g.significantDigits;
+  dbg << '}';
+  return dbg;
+}
+
+//-----------------------------------------------------------------------------
+QList<ExpectedStringGroup> adapt(QVector<StringGroup> const& v)
+{
+    QList<ExpectedStringGroup> out;
+    foreach (auto const& g, v)
+        out.append(g);
+
+    return out;
+}
+
+//-----------------------------------------------------------------------------
+void testCrack(qtTest& t_obj, QString const& s,
+               QList<ExpectedStringGroup> const& x)
+{
+    TEST_EQUAL(adapt(crack(s)), x);
+}
+
+//-----------------------------------------------------------------------------
+void testCrackVar(qtTest& t_obj, QString const& s, QString const& v,
+                  QList<ExpectedStringGroup> const& x,
+                  QList<ExpectedStringGroup> const& xPre,
+                  QList<ExpectedStringGroup> const& xPost)
+{
+    TEST_CALL(testCrack, v.arg(s), xPre + x + xPost);
+}
+
+//-----------------------------------------------------------------------------
+void testCrackVars(qtTest& t_obj, QString const& s,
+                   QList<ExpectedStringGroup> const& x)
+{
+    TEST_CALL(testCrackVar, s, "%1", x, {{}}, {});
+    TEST_CALL(testCrackVar, s, "%1.b", x, {{}}, {{".b"}});
+    TEST_CALL(testCrackVar, s, "a%1", x, {{"a"}}, {});
+    TEST_CALL(testCrackVar, s, "a%1.b", x, {{"a"}}, {{".b"}});
+}
+
+//-----------------------------------------------------------------------------
+int testCracking(qtTest& t_obj)
+{
+    TEST_CALL(testCrack, "", {});
+    TEST_CALL(testCrack, "a", {{"a"}});
+    TEST_CALL(testCrack, "aa.b", {{"aa.b"}});
+
+    TEST_CALL(testCrackVars, "0", {{"", 1, 0}});
+    TEST_CALL(testCrackVars, "5", {{"5", 0, 1}});
+    TEST_CALL(testCrackVars, "2x0", {{"2", 0, 1}, {"x"}, {"", 1, 0}});
+    TEST_CALL(testCrackVars, "2x5", {{"2", 0, 1}, {"x"}, {"5", 0, 1}});
+    TEST_CALL(testCrackVars, "2x05", {{"2", 0, 1}, {"x"}, {"5", 1, 1}});
+    TEST_CALL(testCrackVars, "2x50", {{"2", 0, 1}, {"x"}, {"50", 0, 2}});
+    TEST_CALL(testCrackVars, "2x050", {{"2", 0, 1}, {"x"}, {"50", 1, 2}});
+    TEST_CALL(testCrackVars, "02x050", {{"2", 1, 1}, {"x"}, {"50", 1, 2}});
+    TEST_CALL(testCrackVars, special5, {{special5, 0, 1}});
+
+    return 0;
+}
+
+//-----------------------------------------------------------------------------
+void testCompVar(qtTest& t_obj, QString const& s1, QString const& s2,
+                 bool x, QString const& v)
+{
+    static compare c;
+
+    const auto& v1 = v.arg(s1);
+    const auto& v2 = v.arg(s2);
+
+    TEST_EQUAL(c(v1, v1), false);
+    TEST_EQUAL(c(v2, v2), false);
+
+    TEST_EQUAL(c(v2, v1), x);
+    TEST_EQUAL(c(v1, v2), !x);
+}
+
+//-----------------------------------------------------------------------------
+void testCompVars(
+    qtTest& t_obj, QString const& s1, QString const& s2, bool x)
+{
+    TEST_CALL(testCompVar, s1, s2, x, "%1");
+    TEST_CALL(testCompVar, s1, s2, x, "%1.b");
+    TEST_CALL(testCompVar, s1, s2, x, "a%1");
+    TEST_CALL(testCompVar, s1, s2, x, "a%1.b");
+}
+
+//-----------------------------------------------------------------------------
+int testCompare(qtTest& t_obj)
+{
+#define BIGNUM "55555555555555555555555" // To test numbers larger than 2^64
+
+    TEST_CALL(testCompVars, "5", "30", false);
+    TEST_CALL(testCompVars, "05", "30", false);
+    TEST_CALL(testCompVars, "005", "50", false);
+    TEST_CALL(testCompVars, "050", "40", true);
+    TEST_CALL(testCompVars, "050", "50", true);
+    TEST_CALL(testCompVars, "050", "400", false);
+    TEST_CALL(testCompVars, "050", "600", false);
+    TEST_CALL(testCompVars, "05x05", "600", false);
+    TEST_CALL(testCompVars, "05x05", "5x60", false);
+    TEST_CALL(testCompVars, "05x05", "05x60", false);
+    TEST_CALL(testCompVars, "05x05", "06xxx", false);
+    TEST_CALL(testCompVars, "05x05", "06x05", false);
+    TEST_CALL(testCompVars, BIGNUM "5", BIGNUM "4", true);
+    TEST_CALL(testCompVars, BIGNUM "5", BIGNUM "6", false);
+    TEST_CALL(testCompVars, "a5", "5", true);
+    TEST_CALL(testCompVars, "5", "5a", false);
+    TEST_CALL(testCompVars, "q", "l", true);
+    TEST_CALL(testCompVars, "4", special5, false);
+    TEST_CALL(testCompVars, "5", special5, false);
+    TEST_CALL(testCompVars, "6", special5, true);
+
+    return 0;
+}
+
+//-----------------------------------------------------------------------------
+int main()
+{
+  qtTest t_obj;
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+  // Set locale, so debugging works correctly (at least on UTF-8 systems;
+  // others almost certainly won't be able to display U+1D7FB anyway)...
+  // Only needed for Qt 4; Qt 5 already sets this correctly
+  QTextCodec::setCodecForLocale(QTextCodec::codecForName("UTF-8"));
+#endif
+
+  t_obj.runSuite("Cracking", testCracking);
+  t_obj.runSuite("Comparisons", testCompare);
+  return t_obj.result();
+}

--- a/util/qtNaturalSort.cpp
+++ b/util/qtNaturalSort.cpp
@@ -1,0 +1,200 @@
+/*ckwg +5
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#include "qtNaturalSort.h"
+
+#include <QVector>
+
+namespace qtNaturalSort
+{
+
+namespace // anonymous
+{
+
+//-----------------------------------------------------------------------------
+struct Char
+{
+    uint codePoint;
+    short units;
+
+    bool isDigit() const
+    { return QChar::category(codePoint) == QChar::Number_DecimalDigit; }
+
+    int digitValue() const
+    { return QChar::digitValue(codePoint); }
+};
+
+//-----------------------------------------------------------------------------
+Char getChar(QString const& s, int pos)
+{
+    auto const& c1 = s.at(pos);
+    if (c1.isHighSurrogate() && pos + 1 < s.length())
+    {
+        auto const& c2 = s.at(pos + 1);
+        auto const b1 = c1.unicode() - 0xd800u;
+        auto const b2 = c2.unicode() - 0xdc00u;
+        return {0x10000u + (b1 << 10) + b2, 2};
+    }
+
+    return {c1.unicode(), 1};
+}
+
+//-----------------------------------------------------------------------------
+Char getChar(QStringRef const& s, int pos)
+{
+    auto const& c1 = s.at(pos);
+    if (c1.isHighSurrogate() && pos + 1 < s.length())
+    {
+        auto const& c2 = s.at(pos + 1);
+        auto const b1 = c1.unicode() - 0xd800u;
+        auto const b2 = c2.unicode() - 0xdc00u;
+        return {0x10000u + (b1 << 10) + b2, 2};
+    }
+
+    return {c1.unicode(), 1};
+}
+
+//-----------------------------------------------------------------------------
+int compareNumbers(StringGroup const& g1, StringGroup const& g2)
+{
+    Q_ASSERT(g1.significantDigits == g2.significantDigits);
+
+    auto const n1 = g1.characters.length();
+    auto const n2 = g2.characters.length();
+    decltype(n1 + 0) i1 = 0;
+    decltype(n2 + 0) i2 = 0;
+
+    while (i1 < n1 && i2 < n2)
+    {
+        auto const& c1 = getChar(g1.characters, i1);
+        auto const& c2 = getChar(g2.characters, i2);
+
+        if (auto const d = (c1.digitValue() - c2.digitValue()))
+            return d;
+
+        i1 += c1.units;
+        i2 += c2.units;
+    }
+
+    return 0;
+}
+
+} // namespace <anonymous>
+
+//-----------------------------------------------------------------------------
+QVector<StringGroup> crack(QString const& s)
+{
+    QVector<StringGroup> out;
+
+    auto const n = s.length();
+    decltype(n + 0) i = 0;
+    decltype(n + 0) j = 0;
+
+    // Iterate over string
+    while (j < n)
+    {
+        // Stop at number groups
+        auto c = getChar(s, j);
+        if (c.isDigit())
+        {
+            // Append non-numeric group to output
+            out.append({s.midRef(i, j - i), 0, 0});
+
+            // Skip leading zeros
+            i = j;
+            while (j < n && c.digitValue() == 0)
+            {
+                j += c.units;
+                if (j < n)
+                {
+                    c = getChar(s, j);
+                    if (!c.isDigit())
+                        break;
+                }
+            }
+            auto const l = j - i;
+
+            // Get numeric part
+            int d = 0;
+            i = j;
+            while (j < n && (c = getChar(s, j)).isDigit())
+            {
+                ++d;
+                j += c.units;
+            }
+
+            // Append numeric group to output
+            out.append({s.midRef(i, j - i), l, d});
+            i = j;
+        }
+        else
+        {
+            ++j;
+        }
+    }
+
+    // Append final non-numeric group to output
+    if (i < j)
+        out.append({s.midRef(i), 0, 0});
+
+    return out;
+}
+
+//-----------------------------------------------------------------------------
+bool compare::operator()(QString const& s1, QString const& s2)
+{
+  auto const& p1 = crack(s1);
+  auto const& p2 = crack(s2);
+
+  auto const n1 = p1.count();
+  auto const n2 = p2.count();
+  auto const n = qMin(n1, n2);
+
+  int ri = 0;
+
+  for (decltype(n + 0) i = 0; i < n; ++i)
+  {
+    // Compare non-numeric group first; if they differ, return result
+    if (auto const r = p1[i].characters.compare(p2[i].characters))
+      return (r < 0);
+
+    // Is there a following non-numeric group?
+    if (++i >= n)
+      break;
+
+    // Compare numeric groups
+    auto const& g1 = p1[i];
+    auto const& g2 = p2[i];
+
+    // If one number has more digits, it must be greater
+    if (g1.significantDigits != g2.significantDigits)
+      return (g1.significantDigits < g2.significantDigits);
+
+    // Otherwise, compare numeric values
+    if (auto r = compareNumbers(g1, g2))
+      return (r < 0);
+
+    // If numeric values are the same, but have different number of leading
+    // zeros, make a note to prefer the one with fewer leading zeros if we
+    // don't find any other differences
+    ri = (ri ? ri : g1.leadingZeros - g2.leadingZeros);
+  }
+
+  // Check for a difference after one string's final numeric group
+  if (n1 != n2)
+    return (n1 < n2);
+
+  // If one numeric group had more leading zeros, consider that one "greater"
+  if (ri)
+    return (ri < 0);
+
+  // If all else fails, fall back to a straight lexicographical comparison
+  // (e.g. two strings that differ only in a numeric group that has the same
+  // value, but uses different types of digits)
+  return (s1 < s2);
+}
+
+} // namespace qtNaturalSort

--- a/util/qtNaturalSort.h
+++ b/util/qtNaturalSort.h
@@ -1,0 +1,87 @@
+/*ckwg +5
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#ifndef __qtNaturalSort_h
+#define __qtNaturalSort_h
+
+#include <qtExports.h>
+
+#include <QString>
+
+template<typename T> class QVector;
+
+namespace qtNaturalSort
+{
+    /// Natural string character group
+    ///
+    /// This structure describes a character group of a natural string. A
+    /// character group consists of either digits or non-digits. A digit group
+    /// has a number of (significant) digits and an optional number of leading
+    /// zero characters, which are not included in \p characters.
+    ///
+    /// Note that a numeric group may consist of only zeros, in which case
+    /// \p characters will be empty.
+    struct StringGroup
+    {
+        QStringRef characters;
+        int leadingZeros;
+        int significantDigits;
+    };
+
+    /// Split a string into "natural" groups
+    ///
+    /// This function splits a string into zero or more groups of characters,
+    /// strictly alternating between non-digit groups and digit groups. The
+    /// first group is always non-digits, and will be empty if the input string
+    /// starts with a digit; otherwise, non-digit groups will never be empty.
+    /// Digit groups may be "empty" iff the group consists only of zeros.
+    ///
+    /// \return Vector of StringGroup instances.
+    ///
+    /// \warning
+    ///   The groups returned by this function \em reference the original
+    ///   string. Callers must take care to not use the returned vector after
+    ///   the input string has been modified or destroyed.
+    QTE_EXPORT QVector<StringGroup> crack(QString const& s);
+
+    /// Functor used to compare two strings "naturally".
+    ///
+    /// This functor is used to perform a "natural" comparison of two strings.
+    /// A "natural" comparison splits each string into sets of numeric and
+    /// non-numeric parts, where "numeric" is defined as "a sequence of digits"
+    /// (Unicode class \c Nd). Non-numeric parts are compared using traditional
+    /// lexicographical ordering, while numeric parts are compared numerically.
+    /// If all non-numeric portions of the string are identical, and all
+    /// numeric portions are numerically identical, the first numeric pair with
+    /// a differing number of leading zeros determines the order. Otherwise,
+    /// pure lexicographical order is used.
+    ///
+    /// Alternate digit forms, including those which require multi-unit
+    /// encoding in UTF-16, are handled properly. Additionally, numeric
+    /// comparison is performed digit by digit, allowing a correct result to be
+    /// produces in the face of arbitrarily long digit sequences.
+    ///
+    /// \note
+    ///   General purpose natural sorting is an impossible problem. In order to
+    ///   produce "correct" results in all cases, the algorithm would need to
+    ///   know additional information such as how to recognize hexadecimal
+    ///   numbers, when to consider a non-ISO date as day/month or month/day,
+    ///   whether to treat \c "1.20" as a floating point number or a version
+    ///   string (i.e. should \c "1.20" be sorted before or after \c "1.5"?),
+    ///   and whether to treat <code>"1,500"<code> as one number, or two
+    ///   numbers separated by punctuation. This algorithm makes no attempt to
+    ///   handle dates, digit separators, non-integers, or hexadecimal numbers.
+    ///   Non-decimal digits and digit separators are treated as non-numeric
+    ///   components.
+    ///
+    /// \sa qtNaturalSort::crack, QChar::isDigit
+    struct QTE_EXPORT compare
+    {
+        bool operator()(QString const& s1, QString const& s2);
+    };
+} // namespace qtNaturalSort
+
+#endif


### PR DESCRIPTION
Add an implementation of "natural" sorting. The objective is to be able to "naturally" sort strings which contain numbers, e.g. to sort "x5" before "x22". This handles [non-ASCII digits](https://www.fileformat.info/info/unicode/category/Nd/list.htm) as well as numbers of any length. However, it has inevitable limitations, which are described in the documentation.

For now, sorting of non-numeric potions is strictly lexicographical. Case insensitivity or locale-aware sorting may be added at some point in the future. (The comparator is set up as a functor rather than a function in order to facilitate this possibility in a hopefully source compatible manner.)