### PR TITLE
Fix build of Designer plugin on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,8 +317,11 @@ if(QTE_BUILD_DESIGNER_PLUGIN)
       Qt5::Core
       Qt5::Gui
       Qt5::Widgets
-      Qt5::Designer
       Qt5::UiPlugin
+    )
+  else()
+    target_link_libraries(${PROJECT_NAME}DesignerPlugin PRIVATE
+      Qt4::QtDesigner
     )
   endif()
 

--- a/designer/qtDesignerWidgetInterface.h
+++ b/designer/qtDesignerWidgetInterface.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -7,7 +7,7 @@
 #ifndef __qtDesignerWidgetInterface_h
 #define __qtDesignerWidgetInterface_h
 
-#include <QtDesigner/QtDesigner>
+#include <QDesignerCustomWidgetInterface>
 
 #include "../core/qtGlobal.h"
 #include "../dom/qtDomElement.h"


### PR DESCRIPTION
So... apparently, the "correct" way of building plugins for Designer changed in Qt5, and, while an attempt was made to preserve compatibility so that the Qt4 method would still work, it turns out it doesn't, for some reason, on macOS.

Fortunately, it appears that porting to the new mechanism is possible. Accordingly, adjust the include header to be the minimum needed header (which is also the correct header for "the new way"), and adjust the link libraries for the plugin so that a) including this header works for both Qt4 and Qt5 and b) we avoid the broken shim header when building against Qt5.

See also https://bugreports.qt.io/browse/QTBUG-73500.