### PR TITLE
Improve handling of compile options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -246,7 +246,8 @@ else()
   set(ONCE_THREAD_LIBRARY -lpthread)
 endif()
 
-target_compile_options(${PROJECT_NAME} INTERFACE ${QTE_REQUIRED_CXX_FLAGS})
+target_compile_options(${PROJECT_NAME}Headers INTERFACE
+  ${QTE_REQUIRED_CXX_FLAGS})
 
 target_include_directories(${PROJECT_NAME}Headers SYSTEM INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>


### PR DESCRIPTION
Use `add_compile_options` instead of directly manipulating `CXX_FLAGS`. Export requirement to tell MSVC to not lie about its C++ version support. Set required flags on the header-only interface target instead of the full library target (the latter will still get them transitively, but the former also needs them).

Fixes #20. @mleotta and/or @RustyBlue, please test and report back; thanks!