### PR TITLE
Fix the install rpath on macOS

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -74,6 +74,7 @@ option(QTE_BUILD_DESIGNER_PLUGIN "Build plugin for Designer" ON)
 # Use RPATH on OS/X
 if(APPLE)
   set(CMAKE_MACOSX_RPATH TRUE)
+  set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 endif()
 
 # Set compiler flags for exports (e.g. -fvisibility=hidden)


### PR DESCRIPTION
To avoid an empty install rpath on macOS we need to set the install
rpath based on the install prefix.