### PR TITLE
Add persistence of QHeaderView state

### DIFF
--- a/util/qtUiState.cpp
+++ b/util/qtUiState.cpp
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -13,6 +13,7 @@
 #include <QDoubleSpinBox>
 #include <QGroupBox>
 #include <QHash>
+#include <QHeaderView>
 #include <QLineEdit>
 #include <QMainWindow>
 #include <QRegExp>
@@ -395,6 +396,16 @@ void qtUiState::mapState(const QString& key, QSplitter* widget)
   qtUiState::AbstractItem* item =
     new qtUiStatePrivate::StateItem<QSplitter>(
     widget, &QSplitter::saveState, &QSplitter::restoreState);
+  d->map(key, item);
+}
+
+//-----------------------------------------------------------------------------
+void qtUiState::mapState(const QString& key, QHeaderView* view)
+{
+  QTE_D(qtUiState);
+  qtUiState::AbstractItem* item =
+    new qtUiStatePrivate::StateItem<QHeaderView>(
+    view, &QHeaderView::saveState, &QHeaderView::restoreState);
   d->map(key, item);
 }
 

--- a/util/qtUiState.h
+++ b/util/qtUiState.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -13,6 +13,7 @@ class QAbstractButton;
 class QAction;
 class QDoubleSpinBox;
 class QGroupBox;
+class QHeaderView;
 class QLineEdit;
 class QMainWindow;
 class QSettings;
@@ -169,6 +170,12 @@ public:
   /// layout of children) of a QSplitter.
   /// \sa QSplitter::saveState, QSplitter::restoreState
   void mapState(const QString& key, QSplitter*);
+  /// Define mapping of a QHeaderView's state.
+  ///
+  /// This method defines a mapping to save and restore the state (section
+  /// sizes and sorting) of a QHeaderView.
+  /// \sa QHeaderView::saveState, QHeaderView::restoreState
+  void mapState(const QString& key, QHeaderView*);
 
   /// Define mapping of a widget's geometry.
   ///


### PR DESCRIPTION
Add a new overload of `qtUiState::mapState` to persist the state of a `QHeaderView`. This allows persisting state of e.g. `QTreeView`. (The part that is interesting to persist is the column sizes and sort order, which is accomplished via the `QHeaderView`.)