### PR TITLE
Improve AUTOMOC with qtExtensions

### DIFF
--- a/cmake/qtExtensionsConfig.cmake.in
+++ b/cmake/qtExtensionsConfig.cmake.in
@@ -5,3 +5,6 @@ set(QTE_QT_VERSION "@QTE_QT_VERSION@")
 
 # Set use file
 set(qtExtensions_USE_FILE ${CMAKE_CURRENT_LIST_DIR}/UseQtExtensions.cmake)
+
+# Additional triggers for AUTOMOC
+list(APPEND CMAKE_AUTOMOC_MACRO_NAMES QTE_BEGIN_META_NAMESPACE)


### PR DESCRIPTION
Since a432e9a14c8b, we provide helper macros that introduce a new mechanism for adding meta-information. Unfortunately, CMake's AUTOMOC does not recognize these out of the box, such that headers that use only these helpers are not processed. Modify our configuration so that our users will automatically have the key macro added to the set of macros that CMake checks when deciding to run AUTOMOC on a header.