### PR TITLE
Create qtCloseButton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ set(qtExtensionsSources
     io/qtKstSeparator.cpp
     io/qtTemporaryFile.cpp
     # Widgets
+    widgets/qtCloseButton.cpp
     widgets/qtColorButton.cpp
     widgets/qtDoubleSlider.cpp
     widgets/qtDrawer.cpp
@@ -181,6 +182,7 @@ set(qtExtensionsInstallHeaders
     io/qtStringStream.h
     io/qtTemporaryFile.h
     # Widgets
+    widgets/qtCloseButton.h
     widgets/qtColorButton.h
     widgets/qtDoubleSlider.h
     widgets/qtDrawer.h
@@ -289,6 +291,7 @@ qte_install_library_targets(${PROJECT_NAME} ${PROJECT_NAME}Headers)
 if(QTE_BUILD_DESIGNER_PLUGIN)
   # Explicitly wrap pure interface headers (that don't have source files)
   qte_wrap_cpp(qtExtensionsDesignerPluginMocSources
+    designer/qtCloseButtonInterface.h
     designer/qtColorButtonInterface.h
     designer/qtDoubleSliderInterface.h
     designer/qtExpanderInterface.h
@@ -360,6 +363,7 @@ set(qtExtensionsWrapObjects
     # IO
     qtTemporaryFile
     # Widgets
+    qtCloseButton
     qtColorButton
     qtDrawerWidget
     qtExpander

--- a/designer/qtCloseButtonInterface.h
+++ b/designer/qtCloseButtonInterface.h
@@ -1,0 +1,35 @@
+/*ckwg +5
+ * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#ifndef __qtCloseButtonInterface_h
+#define __qtCloseButtonInterface_h
+
+#include "qtDesignerWidgetInterface.h"
+
+#include "../widgets/qtCloseButton.h"
+
+class qtCloseButtonInterface
+    : public qtDesignerWidgetInterfaceHelper<qtCloseButton>
+{
+    Q_OBJECT
+    Q_INTERFACES(QDesignerCustomWidgetInterface)
+
+public:
+    qtCloseButtonInterface(QObject* parent = 0)
+        : qtDesignerWidgetInterfaceHelper<qtCloseButton>(parent)
+    {
+    }
+
+    virtual QString toolTip() const QTE_OVERRIDE
+    {
+        return "A styled tool button that shows a window close button";
+    }
+
+private:
+    QTE_DISABLE_COPY(qtCloseButtonInterface)
+};
+
+#endif

--- a/designer/qtDesignerPlugin.cpp
+++ b/designer/qtDesignerPlugin.cpp
@@ -1,11 +1,12 @@
 /*ckwg +5
- * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
 
 #include "qtDesignerPlugin.h"
 
+#include "qtCloseButtonInterface.h"
 #include "qtColorButtonInterface.h"
 #include "qtDoubleSliderInterface.h"
 #include "qtExpanderInterface.h"
@@ -20,6 +21,7 @@ Q_EXPORT_PLUGIN2(qtExtensionsDesignerPlugin, qtDesignerPlugin)
 //-----------------------------------------------------------------------------
 qtDesignerPlugin::qtDesignerPlugin(QObject* parent) : QObject(parent)
 {
+    m_widgets.append(new qtCloseButtonInterface(this));
     m_widgets.append(new qtColorButtonInterface(this));
     m_widgets.append(new qtDoubleSliderInterface(this));
     m_widgets.append(new qtExpanderInterface(this));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ qte_add_test(testSqueezedLabel INTERACTIVE
   SOURCES TestSqueezedLabel.cpp
 )
 
+qte_add_test(testCloseButton        INTERACTIVE TestCloseButton.cpp)
 qte_add_test(testColorButton        INTERACTIVE TestColorButton.cpp)
 qte_add_test(testConfirmationDialog INTERACTIVE TestConfirmationDialog.cpp)
 qte_add_test(testGradientEditor     INTERACTIVE TestGradientEditor.cpp)

--- a/tests/TestCloseButton.cpp
+++ b/tests/TestCloseButton.cpp
@@ -1,0 +1,37 @@
+/*ckwg +5
+ * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#include <QApplication>
+#include <QLabel>
+#include <QTextEdit>
+#include <QGridLayout>
+
+#include "../widgets/qtCloseButton.h"
+
+//-----------------------------------------------------------------------------
+int main(int argc, char** argv)
+{
+    QApplication app(argc, argv);
+
+    QWidget window;
+
+    auto* const layout = new QGridLayout;
+
+    auto* const label = new QLabel{"This is a title", &window};
+    auto* const button = new qtCloseButton{&window};
+    auto* const editor = new QTextEdit{&window};
+
+    layout->addWidget(label, 0, 0);
+    layout->addWidget(button, 0, 1);
+    layout->addWidget(editor, 1, 0, 1, 2);
+
+    window.setLayout(layout);
+
+    window.show();
+    editor->setFocus();
+
+    return app.exec();
+}

--- a/widgets/qtCloseButton.cpp
+++ b/widgets/qtCloseButton.cpp
@@ -1,0 +1,134 @@
+/*ckwg +5
+ * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#include <QEvent>
+#include <QStyle>
+#include <QStylePainter>
+#include <QStyleOptionToolButton>
+
+#include "qtCloseButton.h"
+
+//-----------------------------------------------------------------------------
+class qtCloseButtonPrivate
+{
+public:
+    void updatePixmap(QStyle* style);
+
+    QPixmap pixmap;
+    bool visibleWhenDisabled = true;
+};
+QTE_IMPLEMENT_D_FUNC(qtCloseButton)
+
+//-----------------------------------------------------------------------------
+void qtCloseButtonPrivate::updatePixmap(QStyle *style)
+{
+    auto const size =
+        style->pixelMetric(QStyle::PM_TitleBarButtonIconSize);
+    auto const& icon =
+        style->standardIcon(QStyle::SP_TitleBarCloseButton);
+    this->pixmap = icon.pixmap({size, size});
+}
+
+//-----------------------------------------------------------------------------
+qtCloseButton::qtCloseButton(QWidget* parent)
+  : QToolButton{parent}, d_ptr{new qtCloseButtonPrivate}
+{
+    this->setAutoRaise(true);
+    this->setCheckable(false);
+}
+
+//-----------------------------------------------------------------------------
+qtCloseButton::~qtCloseButton()
+{
+}
+
+//-----------------------------------------------------------------------------
+bool qtCloseButton::visibleWhenDisabled() const
+{
+    QTE_D();
+    return d->visibleWhenDisabled;
+}
+
+//-----------------------------------------------------------------------------
+void qtCloseButton::setVisibleWhenDisabled(bool state)
+{
+    QTE_D();
+
+    d->visibleWhenDisabled = state;
+
+    if (!this->isEnabled())
+    {
+        this->update();
+    }
+}
+
+//-----------------------------------------------------------------------------
+QSize qtCloseButton::sizeHint() const
+{
+    return qtCloseButton::minimumSizeHint();
+}
+
+//-----------------------------------------------------------------------------
+QSize qtCloseButton::minimumSizeHint() const
+{
+    auto const iconSize =
+        this->style()->pixelMetric(QStyle::PM_TitleBarButtonIconSize);
+    auto const frameSize =
+        this->style()->pixelMetric(QStyle::PM_ToolBarFrameWidth);
+    auto const totalSize = iconSize + (2 * frameSize);
+    return {totalSize, totalSize};
+}
+
+//-----------------------------------------------------------------------------
+bool qtCloseButton::event(QEvent *event)
+{
+    QTE_D();
+
+    auto const result = QWidget::event(event);
+
+    switch (event->type())
+    {
+        case QEvent::ApplicationPaletteChange:
+        case QEvent::PaletteChange:
+        case QEvent::StyleChange:
+            d->updatePixmap(this->style());
+            break;
+
+        default:
+            break;
+    }
+
+    return result;
+}
+
+//-----------------------------------------------------------------------------
+void qtCloseButton::paintEvent(QPaintEvent*)
+{
+    QTE_D();
+
+    // Initialize drawing options
+    QStylePainter p{this};
+    QStyleOptionToolButton opt;
+    this->initStyleOption(&opt);
+    opt.text = QString{};
+    opt.icon = QIcon{};
+
+    // Hand off to the style to draw the widget base
+    p.drawComplexControl(QStyle::CC_ToolButton, opt);
+
+    // Draw close 'button'
+    if (this->isEnabled() || d->visibleWhenDisabled)
+    {
+        if (d->pixmap.isNull())
+        {
+            d->updatePixmap(this->style());
+        }
+
+        auto const frameSize =
+            this->style()->pixelMetric(QStyle::PM_ToolBarFrameWidth);
+        p.drawPixmap(QPoint{frameSize, frameSize}, d->pixmap);
+    }
+}

--- a/widgets/qtCloseButton.h
+++ b/widgets/qtCloseButton.h
@@ -1,0 +1,46 @@
+/*ckwg +5
+ * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#ifndef __qtCloseButton_h
+#define __qtCloseButton_h
+
+#include <QToolButton>
+
+#include "../core/qtGlobal.h"
+
+class qtCloseButtonPrivate;
+
+class QTE_EXPORT qtCloseButton : public QToolButton
+{
+    Q_OBJECT
+    Q_PROPERTY(bool visibleWhenDisabled
+               READ visibleWhenDisabled
+               WRITE setVisibleWhenDisabled)
+
+public:
+    qtCloseButton(QWidget* parent = 0);
+    ~qtCloseButton();
+
+    QSize sizeHint() const override;
+    QSize minimumSizeHint() const override;
+
+    bool visibleWhenDisabled() const;
+
+public slots:
+    void setVisibleWhenDisabled(bool);
+
+protected:
+    QTE_DECLARE_PRIVATE_RPTR(qtCloseButton)
+
+    bool event(QEvent *event) override;
+    void paintEvent(QPaintEvent*) override;
+
+private:
+    QTE_DECLARE_PRIVATE(qtCloseButton)
+    QTE_DISABLE_COPY(qtCloseButton)
+};
+
+#endif


### PR DESCRIPTION
Create a new button widget, somewhat similar to `qtExpander`, that displays a dock-style close button. This is useful for dynamic views that are not based on tabs.