### PR TITLE
Improve qtThrobber

### DIFF
--- a/widgets/qtThrobber.cpp
+++ b/widgets/qtThrobber.cpp
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -19,33 +19,57 @@ QTE_IMPLEMENT_D_FUNC(qtThrobber)
 class qtThrobberPrivate
 {
 public:
-  static const int dotCount = 12;
+    constexpr static auto dotCount = 12;
 
-  QTimer timer;
-  int step;
-  int maxSize;
+    QTimer timer;
+    int step = -1;
+    int maxSize = -1;
+    qreal opacity = 0.0;
+    qtThrobber::Style style = qtThrobber::BlackAndWhite;
 
-  QBrush brushAt(int pos);
+    QBrush brushAt(QPalette const& palette, int pos,
+                   QPalette::ColorGroup group, QPalette::ColorRole role);
 };
 
 //-----------------------------------------------------------------------------
-QBrush qtThrobberPrivate::brushAt(int pos)
+QBrush qtThrobberPrivate::brushAt(
+    QPalette const& palette, int pos,
+    QPalette::ColorGroup group, QPalette::ColorRole role)
 {
-  qreal a = ((dotCount + pos - this->step) % dotCount);
-  a = 0.1 + (0.75 * pow(a / dotCount, 2.2));
-  int c = qRound(a * 255.0);
-  return QColor{c, c, c};
+    constexpr auto k = qtThrobberPrivate::dotCount;
+    constexpr auto ki = qreal{1.0} / static_cast<qreal>(k - 1);
+
+    auto a = static_cast<qreal>((k + pos - this->step) % k) * ki;
+    a = std::pow(a, 2.2);
+
+    if (this->style == qtThrobber::TranslucentForeground)
+    {
+        auto c = palette.color(group, role);
+        c.setAlphaF(a);
+        return c;
+    }
+
+    a = 0.1 + (0.8 * a);
+    return QColor::fromRgbF(a, a, a);
 }
 
 //-----------------------------------------------------------------------------
 qtThrobber::qtThrobber(QWidget* parent)
-  : QWidget(parent), d_ptr(new qtThrobberPrivate)
+    : QWidget(parent), d_ptr(new qtThrobberPrivate)
 {
-  QTE_D(qtThrobber);
-  connect(&d->timer, SIGNAL(timeout()), this, SLOT(step()));
-  d->timer.setInterval(120);
-  d->step = -1;
-  d->maxSize = -1;
+    QTE_D();
+
+    this->setBackgroundRole(QPalette::Window);
+    this->setForegroundRole(QPalette::WindowText);
+
+    connect(
+        &d->timer, &QTimer::timeout, this,
+        [this, d]{
+            d->step = (d->step + 1) % qtThrobberPrivate::dotCount;
+            this->update();
+        });
+
+    d->timer.setInterval(120);
 }
 
 //-----------------------------------------------------------------------------
@@ -56,90 +80,125 @@ qtThrobber::~qtThrobber()
 //-----------------------------------------------------------------------------
 QSize qtThrobber::minimumSizeHint() const
 {
-  return {12, 12};
+    return {12, 12};
 }
 
 //-----------------------------------------------------------------------------
 void qtThrobber::setActive(bool active)
 {
-  QTE_D(qtThrobber);
-  if (active)
+    QTE_D();
+    if (active)
     {
-    d->step = 0;
-    d->timer.start();
+        d->step = 0;
+        d->timer.start();
     }
-  else
+    else
     {
-    d->timer.stop();
-    d->step = -1;
-    this->update();
+        d->timer.stop();
+        d->step = -1;
+        this->update();
     }
 }
 
 //-----------------------------------------------------------------------------
 bool qtThrobber::isActive() const
 {
-  QTE_D_CONST(qtThrobber);
-  return d->timer.isActive();
+    QTE_D();
+    return d->timer.isActive();
+}
+
+//-----------------------------------------------------------------------------
+void qtThrobber::setStyle(Style s)
+{
+    QTE_D();
+    d->style = s;
+    this->update();
+}
+
+//-----------------------------------------------------------------------------
+qtThrobber::Style qtThrobber::style() const
+{
+    QTE_D();
+    return d->style;
+}
+
+//-----------------------------------------------------------------------------
+void qtThrobber::setOpacity(qreal o)
+{
+    QTE_D();
+    d->opacity = o;
+    this->update();
+}
+
+//-----------------------------------------------------------------------------
+qreal qtThrobber::opacity() const
+{
+    QTE_D();
+    return d->opacity;
 }
 
 //-----------------------------------------------------------------------------
 void qtThrobber::setMaxThrobberSize(int s)
 {
-  QTE_D(qtThrobber);
-  d->maxSize = s;
+    QTE_D();
+    d->maxSize = s;
+    this->update();
 }
 
 //-----------------------------------------------------------------------------
 int qtThrobber::maxThrobberSize() const
 {
-  QTE_D_CONST(qtThrobber);
-  return d->maxSize;
-}
-
-//-----------------------------------------------------------------------------
-void qtThrobber::step()
-{
-  QTE_D(qtThrobber);
-  d->step = (d->step + 1) % qtThrobberPrivate::dotCount;
-  this->update();
+    QTE_D();
+    return d->maxSize;
 }
 
 //-----------------------------------------------------------------------------
 void qtThrobber::paintEvent(QPaintEvent* e)
 {
-  QTE_D(qtThrobber);
+    QTE_D();
 
-  // Do nothing if inactive
-  if (d->step < 0)
+    // Do nothing if inactive
+    if (d->step < 0)
     {
-    QWidget::paintEvent(e);
-    return;
+        QWidget::paintEvent(e);
+        return;
     }
 
-  qreal x = this->width() * 0.5, y = this->height() * 0.5;
-  qreal s = qMin(x, y), m = d->maxSize;
-  const qreal r = 3.0;
+    qreal x = this->width() * 0.5, y = this->height() * 0.5;
+    qreal s = qMin(x, y), m = d->maxSize;
+    const qreal r = 3.0;
 
-  if (m > 0)
+    if (m > 0)
     {
-    s = qMin(s, m);
+        s = qMin(s, m);
     }
 
-  QPainter painter(this);
+    QPainter painter(this);
+    auto palette = this->palette();
 
-  painter.setRenderHint(QPainter::Antialiasing);
-  painter.translate(x, y);
-  painter.scale(s * 0.04, s * 0.04);
+    auto const active = this->isActiveWindow();
+    auto const cg = (active ? QPalette::Active : QPalette::Inactive);
+    auto const cr = this->foregroundRole();
 
-  painter.setPen(Qt::NoPen);
-
-  foreach (auto const i, qtIndexRange(qtThrobberPrivate::dotCount))
+    if (d->opacity > 0.0)
     {
-    painter.save();
-    painter.setBrush(d->brushAt(i));
-    painter.rotate((360.0 / qtThrobberPrivate::dotCount) * i);
-    painter.drawEllipse(QRectF{-20.0 - r, -r, 2.0 * r, 2.0 * r});
-    painter.restore();
+        auto c = palette.color(cg, this->backgroundRole());
+        c.setAlphaF(d->opacity);
+        painter.fillRect(this->rect(), c);
+    }
+
+    painter.setRenderHint(QPainter::Antialiasing);
+    painter.translate(x, y);
+    painter.scale(s * 0.04, s * 0.04);
+
+    painter.setPen(Qt::NoPen);
+
+    for (auto const i : qtIndexRange(qtThrobberPrivate::dotCount))
+    {
+        painter.save();
+        painter.setBrush(d->brushAt(palette, i, cg, cr));
+        painter.rotate((360.0 / qtThrobberPrivate::dotCount) * i);
+        painter.drawEllipse(QRectF{-20.0 - r, -r, 2.0 * r, 2.0 * r});
+        painter.restore();
     }
 }

--- a/widgets/qtThrobber.h
+++ b/widgets/qtThrobber.h
@@ -15,37 +15,49 @@ class qtThrobberPrivate;
 
 class QTE_EXPORT qtThrobber : public QWidget
 {
-  Q_OBJECT
+    Q_OBJECT
 
-  Q_PROPERTY(bool active READ isActive WRITE setActive)
-  Q_PROPERTY(int maxThrobberSize READ maxThrobberSize WRITE setMaxThrobberSize)
+    Q_PROPERTY(bool active READ isActive WRITE setActive)
+    Q_PROPERTY(int maxThrobberSize
+               READ maxThrobberSize
+               WRITE setMaxThrobberSize)
+    Q_PROPERTY(Style style READ style WRITE setStyle)
+    Q_PROPERTY(qreal opacity READ opacity WRITE setOpacity)
 
 public:
-  qtThrobber(QWidget* parent = 0);
-  virtual ~qtThrobber();
+    enum Style
+    {
+        BlackAndWhite,
+        TranslucentForeground,
+    };
+    Q_ENUM(Style)
 
-  QSize minimumSizeHint() const;
-  bool isActive() const;
-  int maxThrobberSize() const;
+    qtThrobber(QWidget* parent = 0);
+    virtual ~qtThrobber();
+
+    QSize minimumSizeHint() const;
+    bool isActive() const;
+    Style style() const;
+    qreal opacity() const;
+    int maxThrobberSize() const;
 
 signals:
-  void toggled(bool);
+    void toggled(bool);
 
 public slots:
-  void setActive(bool);
-  void setMaxThrobberSize(int);
-
-protected slots:
-  void step();
+    void setActive(bool);
+    void setStyle(Style);
+    void setOpacity(qreal);
+    void setMaxThrobberSize(int);
 
 protected:
-  QTE_DECLARE_PRIVATE_RPTR(qtThrobber)
+    QTE_DECLARE_PRIVATE_RPTR(qtThrobber)
 
-  void paintEvent(QPaintEvent*);
+    void paintEvent(QPaintEvent*);
 
 private:
-  QTE_DECLARE_PRIVATE(qtThrobber)
-  QTE_DISABLE_COPY(qtThrobber)
+    QTE_DECLARE_PRIVATE(qtThrobber)
+    QTE_DISABLE_COPY(qtThrobber)
 };
 
 #endif


### PR DESCRIPTION
Add ability to paint a translucent background to `qtThrobber`, which is useful when using it as an overlay on another widget. Add (limited) ability to change the throbber colors. Slightly tweak the default colors.