### PR TITLE
Replace copyright notices

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2015 Kitware, Inc.
+Copyright 2020 Kitware, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/core/qtCliArgs.cpp
+++ b/core/qtCliArgs.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtCliArgs.h"
 

--- a/core/qtCliArgs.h
+++ b/core/qtCliArgs.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtCliArgs_h
 #define __qtCliArgs_h

--- a/core/qtCliOption.cpp
+++ b/core/qtCliOption.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtCliOption.h"
 

--- a/core/qtCliOption.h
+++ b/core/qtCliOption.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtCliOption_h
 #define __qtCliOption_h

--- a/core/qtCliOptions.cpp
+++ b/core/qtCliOptions.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtCliOptions.h"
 

--- a/core/qtCliOptions.h
+++ b/core/qtCliOptions.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtCliOptions_h
 #define __qtCliOptions_h

--- a/core/qtDebug.cpp
+++ b/core/qtDebug.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtDebugImpl.h"
 

--- a/core/qtDebug.h
+++ b/core/qtDebug.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtDebug_h
 #define __qtDebug_h

--- a/core/qtDebugArea.h
+++ b/core/qtDebugArea.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtDebugArea_h
 #define __qtDebugArea_h

--- a/core/qtDebugHelper.h
+++ b/core/qtDebugHelper.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtDebugHelper_h
 #define __qtDebugHelper_h

--- a/core/qtDebugImpl.h
+++ b/core/qtDebugImpl.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtDebugImpl_h
 #define __qtDebugImpl_h

--- a/core/qtEnableSharedFromThis.h
+++ b/core/qtEnableSharedFromThis.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtEnableSharedFromThis_h
 #define __qtEnableSharedFromThis_h

--- a/core/qtEnumerate.h
+++ b/core/qtEnumerate.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtEnumerate_h
 #define __qtEnumerate_h

--- a/core/qtGet.h
+++ b/core/qtGet.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtGet_h
 #define __qtGet_h

--- a/core/qtGlobal.h
+++ b/core/qtGlobal.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtGlobal_h
 #define __qtGlobal_h

--- a/core/qtIndexRange.h
+++ b/core/qtIndexRange.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 // Based on code written by Matthew Woehlke and used by permission.
 

--- a/core/qtMath.h
+++ b/core/qtMath.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtMath_h
 #define __qtMath_h

--- a/core/qtOnce.cpp
+++ b/core/qtOnce.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtOnce.h"
 

--- a/core/qtOnce.h
+++ b/core/qtOnce.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtOnce_h
 #define __qtOnce_h

--- a/core/qtScopedValueChange.cpp
+++ b/core/qtScopedValueChange.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include <QTreeWidget>
 

--- a/core/qtScopedValueChange.h
+++ b/core/qtScopedValueChange.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtScopedValueChange_h
 #define __qtScopedValueChange_h

--- a/core/qtStlUtil.h
+++ b/core/qtStlUtil.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtStlUtil_h
 #define __qtStlUtil_h

--- a/core/qtTest.cpp
+++ b/core/qtTest.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtTest.h"
 

--- a/core/qtTest.h
+++ b/core/qtTest.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtTest_h
 #define __qtTest_h

--- a/core/qtThread.cpp
+++ b/core/qtThread.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtThread.h"
 

--- a/core/qtThread.h
+++ b/core/qtThread.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtThread_h
 #define __qtThread_h

--- a/core/qtTransferablePointer.h
+++ b/core/qtTransferablePointer.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtTransferablePointer_h
 #define __qtTransferablePointer_h

--- a/core/qtTransferablePointerArray.h
+++ b/core/qtTransferablePointerArray.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtTransferablePointerArray_h
 #define __qtTransferablePointerArray_h

--- a/core/qtUtil.cpp
+++ b/core/qtUtil.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtUtil.h"
 

--- a/core/qtUtil.h
+++ b/core/qtUtil.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtUtil_h
 #define __qtUtil_h

--- a/designer/qtCloseButtonInterface.h
+++ b/designer/qtCloseButtonInterface.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtCloseButtonInterface_h
 #define __qtCloseButtonInterface_h

--- a/designer/qtColorButtonInterface.h
+++ b/designer/qtColorButtonInterface.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtColorButtonInterface_h
 #define __qtColorButtonInterface_h

--- a/designer/qtDesignerPlugin.cpp
+++ b/designer/qtDesignerPlugin.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtDesignerPlugin.h"
 

--- a/designer/qtDesignerPlugin.h
+++ b/designer/qtDesignerPlugin.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtDesignerPlugin_h
 #define __qtDesignerPlugin_h

--- a/designer/qtDesignerWidgetInterface.cpp
+++ b/designer/qtDesignerWidgetInterface.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtDesignerWidgetInterface.h"
 

--- a/designer/qtDesignerWidgetInterface.h
+++ b/designer/qtDesignerWidgetInterface.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtDesignerWidgetInterface_h
 #define __qtDesignerWidgetInterface_h

--- a/designer/qtDoubleSliderInterface.h
+++ b/designer/qtDoubleSliderInterface.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtDoubleSliderInterface_h
 #define __qtDoubleSliderInterface_h

--- a/designer/qtExpanderInterface.h
+++ b/designer/qtExpanderInterface.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtExpanderInterface_h
 #define __qtExpanderInterface_h

--- a/designer/qtOverlayWidgetInterface.h
+++ b/designer/qtOverlayWidgetInterface.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtOverlayWidgetInterface_h
 #define __qtOverlayWidgetInterface_h

--- a/designer/qtProgressWidgetInterface.h
+++ b/designer/qtProgressWidgetInterface.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtProgressWidgetInterface_h
 #define __qtProgressWidgetInterface_h

--- a/designer/qtSqueezedLabelInterface.h
+++ b/designer/qtSqueezedLabelInterface.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtSqueezedLabelInterface_h
 #define __qtSqueezedLabelInterface_h

--- a/designer/qtThrobberInterface.h
+++ b/designer/qtThrobberInterface.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtThrobberInterface_h
 #define __qtThrobberInterface_h

--- a/dialogs/qtActionManagerDialog.cpp
+++ b/dialogs/qtActionManagerDialog.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtActionManagerDialog.h"
 #include "ui_qtActionManagerDialog.h"

--- a/dialogs/qtActionManagerDialog.h
+++ b/dialogs/qtActionManagerDialog.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtActionManagerDialog_h
 #define __qtActionManagerDialog_h

--- a/dialogs/qtConfirmationDialog.cpp
+++ b/dialogs/qtConfirmationDialog.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtConfirmationDialog.h"
 #include "ui_qtConfirmationDialog.h"

--- a/dialogs/qtConfirmationDialog.h
+++ b/dialogs/qtConfirmationDialog.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtConfirmationDialog_h
 #define __qtConfirmationDialog_h

--- a/dialogs/qtDoubleInputDialog.cpp
+++ b/dialogs/qtDoubleInputDialog.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtDoubleInputDialog.h"
 

--- a/dialogs/qtDoubleInputDialog.h
+++ b/dialogs/qtDoubleInputDialog.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtDoubleInputDialog_h
 #define __qtDoubleInputDialog_h

--- a/dialogs/qtGradientEditor.cpp
+++ b/dialogs/qtGradientEditor.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtGradientEditor.h"
 #include "ui_qtGradientEditor.h"

--- a/dialogs/qtGradientEditor.h
+++ b/dialogs/qtGradientEditor.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtGradientEditor_h
 #define __qtGradientEditor_h

--- a/dom/qtDom.cpp
+++ b/dom/qtDom.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtDom.h"
 

--- a/dom/qtDom.h
+++ b/dom/qtDom.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtDom_h
 #define __qtDom_h

--- a/dom/qtDomElement.cpp
+++ b/dom/qtDomElement.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2012 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtDomElement.h"
 

--- a/dom/qtDomElement.h
+++ b/dom/qtDomElement.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtDomElement_h
 #define __qtDomElement_h

--- a/io/qtKstParser.cpp
+++ b/io/qtKstParser.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtKstParser.h"
 

--- a/io/qtKstParser.h
+++ b/io/qtKstParser.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include <QString>
 

--- a/io/qtKstReader.cpp
+++ b/io/qtKstReader.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtKstReader.h"
 

--- a/io/qtKstReader.h
+++ b/io/qtKstReader.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtKstReader_h
 #define __qtKstReader_h

--- a/io/qtKstSeparator.cpp
+++ b/io/qtKstSeparator.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtKstSeparator.h"
 

--- a/io/qtKstSeparator.h
+++ b/io/qtKstSeparator.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "../core/qtGlobal.h"
 

--- a/io/qtStringStream.h
+++ b/io/qtStringStream.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtStringStream_h
 #define __qtStringStream_h

--- a/io/qtTemporaryFile.cpp
+++ b/io/qtTemporaryFile.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include <QDir>
 #include <QScopedArrayPointer>

--- a/io/qtTemporaryFile.h
+++ b/io/qtTemporaryFile.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtTemporaryFile_h
 #define __qtTemporaryFile_h

--- a/itemviews/qtAbstractListDelegate.cpp
+++ b/itemviews/qtAbstractListDelegate.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtAbstractListDelegate.h"
 

--- a/itemviews/qtAbstractListDelegate.h
+++ b/itemviews/qtAbstractListDelegate.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtAbstractListDelegate_h
 #define __qtAbstractListDelegate_h

--- a/itemviews/qtColorButtonItemWidget.cpp
+++ b/itemviews/qtColorButtonItemWidget.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtColorButtonItemWidget.h"
 

--- a/itemviews/qtColorButtonItemWidget.h
+++ b/itemviews/qtColorButtonItemWidget.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtColorButtonItemWidget_h
 #define __qtColorButtonItemWidget_h

--- a/itemviews/qtComboBoxDelegate.cpp
+++ b/itemviews/qtComboBoxDelegate.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtComboBoxDelegate.h"
 

--- a/itemviews/qtComboBoxDelegate.h
+++ b/itemviews/qtComboBoxDelegate.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtComboBoxDelegate_h
 #define __qtComboBoxDelegate_h

--- a/itemviews/qtDoubleSpinBoxDelegate.cpp
+++ b/itemviews/qtDoubleSpinBoxDelegate.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtDoubleSpinBoxDelegate.h"
 

--- a/itemviews/qtDoubleSpinBoxDelegate.h
+++ b/itemviews/qtDoubleSpinBoxDelegate.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtDoubleSpinBoxDelegate_h
 #define __qtDoubleSpinBoxDelegate_h

--- a/itemviews/qtFlagListDelegate.h
+++ b/itemviews/qtFlagListDelegate.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtFlagListDelegate_h
 #define __qtFlagListDelegate_h

--- a/itemviews/qtListDelegate.cpp
+++ b/itemviews/qtListDelegate.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtListDelegate.h"
 

--- a/itemviews/qtListDelegate.h
+++ b/itemviews/qtListDelegate.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtListDelegate_h
 #define __qtListDelegate_h

--- a/itemviews/qtNumericTreeWidgetItem.h
+++ b/itemviews/qtNumericTreeWidgetItem.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2012 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtNumericTreeWidgetItem_h
 #define __qtNumericTreeWidgetItem_h

--- a/itemviews/qtRichTextDelegate.cpp
+++ b/itemviews/qtRichTextDelegate.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtRichTextDelegate.h"
 

--- a/itemviews/qtRichTextDelegate.h
+++ b/itemviews/qtRichTextDelegate.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtRichTextDelegate_h
 #define __qtRichTextDelegate_h

--- a/itemviews/qtSpinBoxDelegate.cpp
+++ b/itemviews/qtSpinBoxDelegate.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtSpinBoxDelegate.h"
 

--- a/itemviews/qtSpinBoxDelegate.h
+++ b/itemviews/qtSpinBoxDelegate.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtSpinBoxDelegate_h
 #define __qtSpinBoxDelegate_h

--- a/qteDParadigm.dox
+++ b/qteDParadigm.dox
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2012 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 /**
 \page QTE_D QtExtensions' D-Pointer Paradigm

--- a/sax/qtSax.h
+++ b/sax/qtSax.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtSax_h
 #define __qtSax_h

--- a/sax/qtSaxNamespace.h
+++ b/sax/qtSaxNamespace.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtSaxNamespace_h
 #define __qtSaxNamespace_h

--- a/sax/qtSaxNodes.cpp
+++ b/sax/qtSaxNodes.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtSaxNodes.h"
 

--- a/sax/qtSaxNodes.h
+++ b/sax/qtSaxNodes.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtSaxNodes_h
 #define __qtSaxNodes_h

--- a/sax/qtSaxTraversal.cpp
+++ b/sax/qtSaxTraversal.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtSaxTraversal.h"
 

--- a/sax/qtSaxTraversal.h
+++ b/sax/qtSaxTraversal.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtSaxTraversal_h
 #define __qtSaxTraversal_h

--- a/sax/qtSaxWriter.cpp
+++ b/sax/qtSaxWriter.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtSaxWriter.h"
 

--- a/sax/qtSaxWriter.h
+++ b/sax/qtSaxWriter.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtSaxWriter_h
 #define __qtSaxWriter_h

--- a/tests/TestCloseButton.cpp
+++ b/tests/TestCloseButton.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include <QApplication>
 #include <QLabel>

--- a/tests/TestColorButton.cpp
+++ b/tests/TestColorButton.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include <QApplication>
 #include <QCheckBox>

--- a/tests/TestConfirmationDialog.cpp
+++ b/tests/TestConfirmationDialog.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include <QApplication>
 #include <QLabel>

--- a/tests/TestDoubleSlider.cpp
+++ b/tests/TestDoubleSlider.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "TestDoubleSlider.h"
 

--- a/tests/TestDoubleSlider.h
+++ b/tests/TestDoubleSlider.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __TestDoubleSlider_h
 #define __TestDoubleSlider_h

--- a/tests/TestDrawers.cpp
+++ b/tests/TestDrawers.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "TestDrawers.h"
 

--- a/tests/TestDrawers.h
+++ b/tests/TestDrawers.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __TestDrawers_h
 #define __TestDrawers_h

--- a/tests/TestExpander.cpp
+++ b/tests/TestExpander.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "TestExpander.h"
 

--- a/tests/TestExpander.h
+++ b/tests/TestExpander.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __TestExpander_h
 #define __TestExpander_h

--- a/tests/TestGradientEditor.cpp
+++ b/tests/TestGradientEditor.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include <QApplication>
 #include <QDebug>

--- a/tests/TestGradientWidget.cpp
+++ b/tests/TestGradientWidget.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include <QApplication>
 

--- a/tests/TestKst.cpp
+++ b/tests/TestKst.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include <cstdio>
 

--- a/tests/TestNaturalSort.cpp
+++ b/tests/TestNaturalSort.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #define TEST_OBJECT_NAME t_obj
 

--- a/tests/TestProgressWidget.cpp
+++ b/tests/TestProgressWidget.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "../widgets/qtProgressWidget.h"
 

--- a/tests/TestSqueezedLabel.cpp
+++ b/tests/TestSqueezedLabel.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "TestSqueezedLabel.h"
 

--- a/tests/TestSqueezedLabel.h
+++ b/tests/TestSqueezedLabel.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __TestSqueezedLabel_h
 #define __TestSqueezedLabel_h

--- a/tests/TestThrobber.cpp
+++ b/tests/TestThrobber.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include <QApplication>
 #include <QLabel>

--- a/tests/TestUiState.cpp
+++ b/tests/TestUiState.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #define TEST_OBJECT_NAME t_obj
 
@@ -28,7 +26,6 @@
   QTemporaryFile _tempFile("settings-XXXXXX.ini"); \
   if (TEST_EQUAL(_tempFile.open(), true)) return 1; \
   qtUiState _state(new QSettings(_tempFile.fileName(), QSettings::IniFormat))
-
 
 //-----------------------------------------------------------------------------
 class IntItem : public qtUiState::AbstractItem

--- a/tests/qtEditableLabel.cpp
+++ b/tests/qtEditableLabel.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtEditableLabel.h"
 

--- a/tests/qtEditableLabel.h
+++ b/tests/qtEditableLabel.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtEditableLabel_h
 #define __qtEditableLabel_h

--- a/tools/qtActionManagerCompiler.cpp
+++ b/tools/qtActionManagerCompiler.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qteVersion.h"
 

--- a/tools/qtMakeDoxyTags.cpp
+++ b/tools/qtMakeDoxyTags.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include <QDebug>
 #include <QDir>

--- a/util/qtAbstractAnimation.cpp
+++ b/util/qtAbstractAnimation.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include <cmath>
 

--- a/util/qtAbstractAnimation.h
+++ b/util/qtAbstractAnimation.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtAbstractAnimation_h
 #define __qtAbstractAnimation_h

--- a/util/qtAbstractSetting.cpp
+++ b/util/qtAbstractSetting.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtAbstractSetting.h"
 

--- a/util/qtAbstractSetting.h
+++ b/util/qtAbstractSetting.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtAbstractSetting_h
 #define __qtAbstractSetting_h

--- a/util/qtActionFactory.cpp
+++ b/util/qtActionFactory.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtActionFactory.h"
 

--- a/util/qtActionFactory.h
+++ b/util/qtActionFactory.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtActionFactory_h
 #define __qtActionFactory_h

--- a/util/qtActionManager.cpp
+++ b/util/qtActionManager.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtActionManager.h"
 

--- a/util/qtActionManager.h
+++ b/util/qtActionManager.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtActionManager_h
 #define __qtActionManager_h

--- a/util/qtActionPriorityList.cpp
+++ b/util/qtActionPriorityList.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtActionPriorityList.h"
 

--- a/util/qtActionPriorityList.h
+++ b/util/qtActionPriorityList.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtActionPriorityList_h
 #define __qtActionPriorityList_h

--- a/util/qtColorScheme.cpp
+++ b/util/qtColorScheme.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtColorScheme.h"
 

--- a/util/qtColorScheme.h
+++ b/util/qtColorScheme.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtColorScheme_h
 #define __qtColorScheme_h

--- a/util/qtColorUtil.cpp
+++ b/util/qtColorUtil.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtColorUtil.h"
 

--- a/util/qtColorUtil.h
+++ b/util/qtColorUtil.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtColorUtil_h
 #define __qtColorUtil_h

--- a/util/qtDockController.cpp
+++ b/util/qtDockController.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include <QAction>
 #include <QDebug>

--- a/util/qtDockController.h
+++ b/util/qtDockController.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtDockController_h
 #define __qtDockController_h

--- a/util/qtDockControllerPrivate.h
+++ b/util/qtDockControllerPrivate.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtDockControllerPrivate_h
 #define __qtDockControllerPrivate_h

--- a/util/qtGradient.cpp
+++ b/util/qtGradient.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtGradient.h"
 

--- a/util/qtGradient.h
+++ b/util/qtGradient.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtGradient_h
 #define __qtGradient_h

--- a/util/qtJson.cpp
+++ b/util/qtJson.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtJson.h"
 

--- a/util/qtJson.h
+++ b/util/qtJson.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtJson_h
 #define __qtJson_h

--- a/util/qtNaturalSort.cpp
+++ b/util/qtNaturalSort.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtNaturalSort.h"
 

--- a/util/qtNaturalSort.h
+++ b/util/qtNaturalSort.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtNaturalSort_h
 #define __qtNaturalSort_h

--- a/util/qtPrioritizedActionContainerProxy.h
+++ b/util/qtPrioritizedActionContainerProxy.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtPrioritizedActionContainerProxy_h
 #define __qtPrioritizedActionContainerProxy_h

--- a/util/qtPrioritizedMenuProxy.cpp
+++ b/util/qtPrioritizedMenuProxy.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtPrioritizedMenuProxy.h"
 

--- a/util/qtPrioritizedMenuProxy.h
+++ b/util/qtPrioritizedMenuProxy.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtPrioritizedMenuProxy_h
 #define __qtPrioritizedMenuProxy_h

--- a/util/qtPrioritizedToolBarProxy.cpp
+++ b/util/qtPrioritizedToolBarProxy.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtPrioritizedToolBarProxy.h"
 

--- a/util/qtPrioritizedToolBarProxy.h
+++ b/util/qtPrioritizedToolBarProxy.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtPrioritizedToolBarProxy_h
 #define __qtPrioritizedToolBarProxy_h

--- a/util/qtProcess.cpp
+++ b/util/qtProcess.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtProcess.h"
 

--- a/util/qtRand.h
+++ b/util/qtRand.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtRand_h
 #define __qtRand_h

--- a/util/qtScopedSettingsGroup.cpp
+++ b/util/qtScopedSettingsGroup.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtScopedSettingsGroup.h"
 

--- a/util/qtScopedSettingsGroup.h
+++ b/util/qtScopedSettingsGroup.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtScopedSettingsGroup_h
 #define __qtScopedSettingsGroup_h

--- a/util/qtSettings.cpp
+++ b/util/qtSettings.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtSettings.h"
 #include "qtSettingsImpl.h"

--- a/util/qtSettings.h
+++ b/util/qtSettings.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtSettings_h
 #define __qtSettings_h

--- a/util/qtSettingsImpl.h
+++ b/util/qtSettingsImpl.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtSettingsImpl_h
 #define __qtSettingsImpl_h

--- a/util/qtStatusForwarder.cpp
+++ b/util/qtStatusForwarder.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtStatusForwarder.h"
 

--- a/util/qtStatusForwarder.h
+++ b/util/qtStatusForwarder.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtStatusForwarder_h
 #define __qtStatusForwarder_h

--- a/util/qtStatusManager.cpp
+++ b/util/qtStatusManager.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include <QtCore>
 

--- a/util/qtStatusManager.h
+++ b/util/qtStatusManager.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtStatusManager_h
 #define __qtStatusManager_h

--- a/util/qtStatusNotifier.cpp
+++ b/util/qtStatusNotifier.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtStatusNotifier.h"
 

--- a/util/qtStatusNotifier.h
+++ b/util/qtStatusNotifier.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtStatusNotifier_h
 #define __qtStatusNotifier_h

--- a/util/qtStatusSource.cpp
+++ b/util/qtStatusSource.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include <QDebug>
 

--- a/util/qtStatusSource.h
+++ b/util/qtStatusSource.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtStatusSource_h
 #define __qtStatusSource_h

--- a/util/qtStatusSourcePrivate.h
+++ b/util/qtStatusSourcePrivate.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtStatusSource.h"
 

--- a/util/qtUiState.cpp
+++ b/util/qtUiState.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtUiState.h"
 #include "qtUiStateItem.h"

--- a/util/qtUiState.h
+++ b/util/qtUiState.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtUiState_h
 #define __qtUiState_h

--- a/util/qtUiStateItem.h
+++ b/util/qtUiStateItem.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtUiStateItem_h
 #define __qtUiStateItem_h

--- a/util/qtUtilNamespace.h
+++ b/util/qtUtilNamespace.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtUtilNamespace_h
 #define __qtUtilNamespace_h

--- a/widgets/qtCloseButton.cpp
+++ b/widgets/qtCloseButton.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include <QEvent>
 #include <QStyle>

--- a/widgets/qtCloseButton.h
+++ b/widgets/qtCloseButton.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtCloseButton_h
 #define __qtCloseButton_h

--- a/widgets/qtColorButton.cpp
+++ b/widgets/qtColorButton.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtColorButton.h"
 

--- a/widgets/qtColorButton.h
+++ b/widgets/qtColorButton.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtColorButton_h
 #define __qtColorButton_h

--- a/widgets/qtDoubleSlider.cpp
+++ b/widgets/qtDoubleSlider.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtDoubleSlider.h"
 

--- a/widgets/qtDoubleSlider.h
+++ b/widgets/qtDoubleSlider.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtDoubleSlider_h
 #define __qtDoubleSlider_h

--- a/widgets/qtDrawer.cpp
+++ b/widgets/qtDrawer.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtDrawer.h"
 

--- a/widgets/qtDrawer.h
+++ b/widgets/qtDrawer.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtDrawer_h
 #define __qtDrawer_h

--- a/widgets/qtDrawerWidget.cpp
+++ b/widgets/qtDrawerWidget.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include <QGridLayout>
 

--- a/widgets/qtDrawerWidget.h
+++ b/widgets/qtDrawerWidget.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtDrawerWidget_h
 #define __qtDrawerWidget_h

--- a/widgets/qtExpander.cpp
+++ b/widgets/qtExpander.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include <QApplication>
 #include <QStyle>

--- a/widgets/qtExpander.h
+++ b/widgets/qtExpander.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtExpander_h
 #define __qtExpander_h

--- a/widgets/qtGradientWidget.cpp
+++ b/widgets/qtGradientWidget.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtGradientWidget.h"
 

--- a/widgets/qtGradientWidget.h
+++ b/widgets/qtGradientWidget.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtGradientWidget_h
 #define __qtGradientWidget_h

--- a/widgets/qtMenu.cpp
+++ b/widgets/qtMenu.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtMenu.h"
 

--- a/widgets/qtMenu.h
+++ b/widgets/qtMenu.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtMenu_h
 #define __qtMenu_h

--- a/widgets/qtOverlayWidget.cpp
+++ b/widgets/qtOverlayWidget.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include <QStackedLayout>
 

--- a/widgets/qtOverlayWidget.h
+++ b/widgets/qtOverlayWidget.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtOverlayWidget_h
 #define __qtOverlayWidget_h

--- a/widgets/qtProgressWidget.cpp
+++ b/widgets/qtProgressWidget.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtProgressWidget.h"
 

--- a/widgets/qtProgressWidget.h
+++ b/widgets/qtProgressWidget.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtProgressWidget_h
 #define __qtProgressWidget_h

--- a/widgets/qtSqueezedLabel.cpp
+++ b/widgets/qtSqueezedLabel.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtSqueezedLabel.h"
 
@@ -341,7 +339,6 @@ bool qtSqueezedLabel::event(QEvent* e)
 
     return QLabel::event(e);
 }
-
 
 //-----------------------------------------------------------------------------
 void qtSqueezedLabel::changeEvent(QEvent* e)

--- a/widgets/qtSqueezedLabel.h
+++ b/widgets/qtSqueezedLabel.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtSqueezedLabel_h
 #define __qtSqueezedLabel_h

--- a/widgets/qtThrobber.cpp
+++ b/widgets/qtThrobber.cpp
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #include "qtThrobber.h"
 

--- a/widgets/qtThrobber.h
+++ b/widgets/qtThrobber.h
@@ -1,8 +1,6 @@
-/*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
- * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
- * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
- */
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
 
 #ifndef __qtThrobber_h
 #define __qtThrobber_h


### PR DESCRIPTION
Update `LICENSE` with the current (for now) year. Replace copyright notices with a simplified notice that does not include the year, which will greatly simplify maintenance (and also uses the correct name of the license file :weary:).