### PR TITLE
Better export dependency on Qt

### DIFF
--- a/cmake/qtExtensionsConfig.cmake.in
+++ b/cmake/qtExtensionsConfig.cmake.in
@@ -1,3 +1,13 @@
+include(CMakeFindDependencyMacro)
+
+if("@QTE_QT_VERSION@" EQUAL 5)
+  if(NOT Qt5_DIR)
+    set(Qt5_DIR "@Qt5_DIR@")
+  endif()
+  set(QTE_REQUIRED_QT_COMPONENTS @Qt5_LINK_MODULES@)
+  find_dependency(Qt5 COMPONENTS ${QTE_REQUIRED_QT_COMPONENTS})
+endif()
+
 # Import library targets
 include(${CMAKE_CURRENT_LIST_DIR}/qtExtensionsConfigTargets.cmake)
 


### PR DESCRIPTION
Modify our package configuration to also search for Qt. This will make it easier for consumers to use us; in particular, without having to know the list of what components we need.