### PR TITLE
Add simple SVG widget

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ set(qtExtensionsSources
     widgets/qtOverlayWidget.cpp
     widgets/qtProgressWidget.cpp
     widgets/qtSqueezedLabel.cpp
+    widgets/qtSvgWidget.cpp
     widgets/qtThrobber.cpp
     # ItemViews
     itemviews/qtAbstractListDelegate.cpp
@@ -187,6 +188,7 @@ set(qtExtensionsInstallHeaders
     widgets/qtOverlayWidget.h
     widgets/qtProgressWidget.h
     widgets/qtSqueezedLabel.h
+    widgets/qtSvgWidget.h
     widgets/qtThrobber.h
     # ItemViews
     itemviews/qtAbstractListDelegate.h
@@ -286,6 +288,7 @@ if(QTE_BUILD_DESIGNER_PLUGIN)
     designer/qtOverlayWidgetInterface.h
     designer/qtProgressWidgetInterface.h
     designer/qtSqueezedLabelInterface.h
+    designer/qtSvgWidgetInterface.h
     designer/qtThrobberInterface.h
     TARGET ${PROJECT_NAME}DesignerPlugin
   )
@@ -308,6 +311,7 @@ if(QTE_BUILD_DESIGNER_PLUGIN)
     Qt5::Core
     Qt5::Gui
     Qt5::Widgets
+    Qt5::Svg
     Qt5::UiPlugin
   )
 
@@ -353,6 +357,7 @@ set(qtExtensionsWrapObjects
     qtMenu
     qtOverlayWidget
     qtProgressWidget
+    qtSvgWidget
     qtThrobber
     # ItemViews
     qtAbstractListDelegate

--- a/cmake/depends-qt5.cmake
+++ b/cmake/depends-qt5.cmake
@@ -1,6 +1,7 @@
 # Build list of required Qt modules
 set(Qt5_LINK_MODULES
   Widgets
+  Svg
   Xml
 )
 

--- a/cmake/testing.cmake
+++ b/cmake/testing.cmake
@@ -25,25 +25,11 @@ function(qte_add_test)
   endif()
 
   # Extract arguments
-  set(_opts "SOURCES;MOC_HEADERS;RESOURCES;UI;LINK_LIBRARIES;ARGS")
+  set(_opts "SOURCES;MOC_HEADERS;LINK_LIBRARIES;ARGS")
   cmake_parse_arguments("" "" "" "${_opts}" ${ARGN})
   list(APPEND _SOURCES ${_UNPARSED_ARGUMENTS}) # Use leftover args as sources
 
   if(NOT TARGET ${_EXECUTABLE})
-    # Handle Qt executables
-    if(NOT "x_${_MOC_HEADERS}" STREQUAL "x_")
-      qte_wrap_cpp(_MOC_SOURCES ${_MOC_HEADERS})
-      list(APPEND _SOURCES ${_MOC_SOURCES})
-    endif()
-    if(NOT "x_${_UI}" STREQUAL "x_")
-      qte_wrap_ui(_UI_SOURCES ${_UI})
-      list(APPEND _SOURCES ${_UI_SOURCES})
-    endif()
-    if(NOT "x_${_RESOURCES}" STREQUAL "x_")
-      qte_add_resources(_RESOURCE_SOURCES ${_RESOURCES})
-      list(APPEND _SOURCES ${_RESOURCE_SOURCES})
-    endif()
-
     # Generate test executable
     add_executable(${_EXECUTABLE} ${_SOURCES})
     target_link_libraries(${_EXECUTABLE}

--- a/designer/qtDesignerPlugin.cpp
+++ b/designer/qtDesignerPlugin.cpp
@@ -10,18 +10,20 @@
 #include "qtExpanderInterface.h"
 #include "qtOverlayWidgetInterface.h"
 #include "qtSqueezedLabelInterface.h"
+#include "qtSvgWidgetInterface.h"
 #include "qtThrobberInterface.h"
 
 //-----------------------------------------------------------------------------
 qtDesignerPlugin::qtDesignerPlugin(QObject* parent) : QObject(parent)
 {
-    m_widgets.append(new qtCloseButtonInterface(this));
-    m_widgets.append(new qtColorButtonInterface(this));
-    m_widgets.append(new qtDoubleSliderInterface(this));
-    m_widgets.append(new qtExpanderInterface(this));
-    m_widgets.append(new qtOverlayWidgetInterface(this));
-    m_widgets.append(new qtSqueezedLabelInterface(this));
-    m_widgets.append(new qtThrobberInterface(this));
+    m_widgets.append(new qtCloseButtonInterface{this});
+    m_widgets.append(new qtColorButtonInterface{this});
+    m_widgets.append(new qtDoubleSliderInterface{this});
+    m_widgets.append(new qtExpanderInterface{this});
+    m_widgets.append(new qtOverlayWidgetInterface{this});
+    m_widgets.append(new qtSqueezedLabelInterface{this});
+    m_widgets.append(new qtSvgWidgetInterface{this});
+    m_widgets.append(new qtThrobberInterface{this});
 }
 
 //-----------------------------------------------------------------------------

--- a/designer/qtSvgWidgetInterface.h
+++ b/designer/qtSvgWidgetInterface.h
@@ -1,0 +1,38 @@
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
+
+#ifndef __qtSvgWidgetInterface_h
+#define __qtSvgWidgetInterface_h
+
+#include "../widgets/qtSvgWidget.h"
+
+#include "qtDesignerWidgetInterface.h"
+
+class qtSvgWidgetInterface
+    : public qtDesignerWidgetInterfaceHelper<qtSvgWidget>
+{
+    Q_OBJECT
+    Q_INTERFACES(QDesignerCustomWidgetInterface)
+
+public:
+    qtSvgWidgetInterface(QObject* parent = 0)
+        : qtDesignerWidgetInterfaceHelper<qtSvgWidget>(parent)
+    {
+    }
+
+    virtual bool isContainer() const QTE_OVERRIDE
+    {
+        return true;
+    }
+
+    virtual QString toolTip() const QTE_OVERRIDE
+    {
+        return "A widget that renders an SVG resource";
+    }
+
+private:
+    QTE_DISABLE_COPY(qtSvgWidgetInterface)
+};
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,8 +4,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 # Interactive tests
 qte_add_test(testDrawers INTERACTIVE
-  SOURCES TestDrawers.cpp qtEditableLabel.cpp
-  RESOURCES icons.qrc
+  SOURCES TestDrawers.cpp qtEditableLabel.cpp icons.qrc
 )
 
 qte_add_test(testExpander INTERACTIVE
@@ -14,7 +13,6 @@ qte_add_test(testExpander INTERACTIVE
 
 qte_add_test(testDoubleSlider INTERACTIVE
   SOURCES TestDoubleSlider.cpp
-  UI testDoubleSlider.ui
 )
 
 qte_add_test(testSqueezedLabel INTERACTIVE
@@ -27,6 +25,7 @@ qte_add_test(testConfirmationDialog INTERACTIVE TestConfirmationDialog.cpp)
 qte_add_test(testGradientEditor     INTERACTIVE TestGradientEditor.cpp)
 qte_add_test(testGradientWidget     INTERACTIVE TestGradientWidget.cpp)
 qte_add_test(testProgressWidget     INTERACTIVE TestProgressWidget.cpp)
+qte_add_test(testSvgWidget          INTERACTIVE TestSvgWidget.cpp)
 qte_add_test(testThrobber           INTERACTIVE TestThrobber.cpp)
 
 # Automated tests

--- a/tests/TestSvgWidget.cpp
+++ b/tests/TestSvgWidget.cpp
@@ -1,0 +1,24 @@
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
+
+#include "../widgets/qtSvgWidget.h"
+
+#include <QApplication>
+
+//-----------------------------------------------------------------------------
+int main(int argc, char** argv)
+{
+    QApplication app{argc, argv};
+
+    qtSvgWidget w;
+
+    if (argc > 1)
+    {
+        w.setResource(argv[1]);
+        w.resize(w.sizeHint());
+    }
+
+    w.show();
+    return app.exec();
+}

--- a/widgets/qtSvgWidget.cpp
+++ b/widgets/qtSvgWidget.cpp
@@ -1,0 +1,210 @@
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
+
+#include "qtSvgWidget.h"
+
+#include <QPainter>
+#include <QPixmapCache>
+#include <QSvgRenderer>
+
+QTE_IMPLEMENT_D_FUNC(qtSvgWidget)
+
+//-----------------------------------------------------------------------------
+class qtSvgWidgetPrivate
+{
+public:
+    QSize adjustedSize(QSize const& in) const;
+
+    QString resource;
+    QSvgRenderer renderer;
+
+    Qt::Alignment alignment = Qt::AlignCenter;
+    bool scaled = true;
+
+    QPixmap cachedPixmap;
+};
+
+//-----------------------------------------------------------------------------
+QSize qtSvgWidgetPrivate::adjustedSize(QSize const& in) const
+{
+    auto const baseSize = this->renderer.defaultSize();
+
+    if (this->scaled)
+    {
+        auto const bw = static_cast<double>(baseSize.width());
+        auto const bh = static_cast<double>(baseSize.height());
+        auto const iw = static_cast<double>(in.width());
+        auto const ih = static_cast<double>(in.height());
+        auto const ba = bw / bh;
+        auto const ia = iw / ih;
+
+        if (ba > ia)
+        {
+            auto const oh = static_cast<int>(iw / ba);
+            return {in.width(), oh};
+        }
+        else
+        {
+            auto ow = static_cast<int>(ih * ba);
+            return {ow, in.height()};
+        }
+    }
+
+    return baseSize;
+}
+
+//-----------------------------------------------------------------------------
+qtSvgWidget::qtSvgWidget(QWidget* parent, Qt::WindowFlags f)
+    : QWidget{parent, f}, d_ptr{new qtSvgWidgetPrivate}
+{
+}
+
+//-----------------------------------------------------------------------------
+qtSvgWidget::qtSvgWidget(
+    QString const& resource, QWidget* parent, Qt::WindowFlags f)
+    : QWidget{parent, f}, d_ptr{new qtSvgWidgetPrivate}
+{
+    this->setResource(resource);
+}
+
+//-----------------------------------------------------------------------------
+qtSvgWidget::~qtSvgWidget()
+{
+}
+
+//-----------------------------------------------------------------------------
+QString qtSvgWidget::resource() const
+{
+    QTE_D();
+    return d->resource;
+}
+
+//-----------------------------------------------------------------------------
+void qtSvgWidget::setResource(QString const& resource)
+{
+    QTE_D();
+
+    if (d->resource != resource)
+    {
+        d->resource = resource;
+        d->cachedPixmap = {};
+
+        d->renderer.load(resource);
+    }
+}
+
+//-----------------------------------------------------------------------------
+Qt::Alignment qtSvgWidget::alignment() const
+{
+    QTE_D();
+    return d->alignment;
+}
+
+//-----------------------------------------------------------------------------
+void qtSvgWidget::setAlignment(Qt::Alignment alignment)
+{
+    QTE_D();
+
+    if (d->alignment != alignment)
+    {
+        d->alignment = alignment;
+        if (d->renderer.isValid())
+        {
+            this->update();
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+bool qtSvgWidget::hasScaledContents() const
+{
+    QTE_D();
+    return d->scaled;
+}
+
+//-----------------------------------------------------------------------------
+void qtSvgWidget::setScaledContents(bool scaled)
+{
+    QTE_D();
+
+    if (d->scaled != scaled)
+    {
+        d->scaled = scaled;
+        if (d->renderer.isValid())
+        {
+            this->update();
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+QSize qtSvgWidget::sizeHint() const
+{
+    QTE_D();
+    return (d->renderer.isValid() ? d->renderer.defaultSize() : QSize{0, 0});
+}
+
+//-----------------------------------------------------------------------------
+QSize qtSvgWidget::minimumSizeHint() const
+{
+    return this->sizeHint();
+}
+
+//-----------------------------------------------------------------------------
+void qtSvgWidget::paintEvent(QPaintEvent* e)
+{
+    QTE_D();
+
+    QPainter painter{this};
+
+    if (this->autoFillBackground())
+    {
+        auto const role = this->backgroundRole();
+        auto const group =
+            [this]{
+                if (!this->isEnabled()) return QPalette::Disabled;
+                if (!this->isActiveWindow()) return QPalette::Inactive;
+                return QPalette::Active;
+            }();
+        auto const& brush = this->palette().brush(group, role);
+
+        painter.fillRect(this->rect(), brush);
+    }
+
+    if (d->renderer.isValid())
+    {
+        auto const size = d->adjustedSize(this->size());
+        auto const dpr = this->devicePixelRatioF();
+        auto const physicalSize = (QSizeF{size} * dpr).toSize();
+
+        if (d->cachedPixmap.isNull() ||
+            d->cachedPixmap.devicePixelRatioF() != dpr ||
+            d->cachedPixmap.size() != physicalSize)
+        {
+            d->cachedPixmap = QPixmap{physicalSize};
+            d->cachedPixmap.setDevicePixelRatio(dpr);
+            d->cachedPixmap.fill(Qt::transparent);
+
+            QPainter pp{&d->cachedPixmap};
+
+            pp.setRenderHint(QPainter::Antialiasing);
+            d->renderer.render(&pp, QRect{{0, 0}, size});
+        }
+
+        auto const r = this->rect();
+        auto const xd = r.width() - size.width();
+        auto const yd = r.height() - size.height();
+
+        auto const a = d->alignment;
+        auto const xs =
+            (a & Qt::AlignRight ? 1.0 : a & Qt::AlignHCenter ? 0.5 : 0.0);
+        auto const ys =
+            (a & Qt::AlignBottom ? 1.0 : a & Qt::AlignVCenter ? 0.5 : 0.0);
+
+        auto const xo = static_cast<int>(static_cast<qreal>(xd) * xs);
+        auto const yo = static_cast<int>(static_cast<qreal>(yd) * ys);
+
+        painter.drawPixmap(r.left() + xo, r.top() + yo, d->cachedPixmap);
+    }
+}

--- a/widgets/qtSvgWidget.h
+++ b/widgets/qtSvgWidget.h
@@ -1,0 +1,52 @@
+// This file is part of qtExtensions, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/qtExtensions/blob/master/LICENSE for details.
+
+#ifndef __qtSvgWidget_h
+#define __qtSvgWidget_h
+
+#include "../core/qtGlobal.h"
+
+#include <QWidget>
+
+class qtSvgWidgetPrivate;
+
+class QTE_EXPORT qtSvgWidget : public QWidget
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QString resource READ resource WRITE setResource)
+    Q_PROPERTY(Qt::Alignment alignment READ alignment WRITE setAlignment)
+    Q_PROPERTY(bool scaledContents
+               READ hasScaledContents WRITE setScaledContents)
+
+public:
+    qtSvgWidget(QWidget* parent = nullptr, Qt::WindowFlags = 0);
+    qtSvgWidget(QString const& resource, QWidget* parent = nullptr,
+                Qt::WindowFlags = 0);
+    virtual ~qtSvgWidget();
+
+    QString resource() const;
+
+    Qt::Alignment alignment() const;
+    bool hasScaledContents() const;
+
+    QSize sizeHint() const override;
+    QSize minimumSizeHint() const override;
+
+public slots:
+    void setResource(QString const&);
+    void setAlignment(Qt::Alignment);
+    void setScaledContents(bool);
+
+protected:
+    QTE_DECLARE_PRIVATE_RPTR(qtSvgWidget)
+
+    virtual void paintEvent(QPaintEvent*);
+
+private:
+    QTE_DECLARE_PRIVATE(qtSvgWidget)
+    QTE_DISABLE_COPY(qtSvgWidget)
+};
+
+#endif


### PR DESCRIPTION
Create a simple widget to render an SVG. Unlike loading an SVG into a QLabel, this supports resizing while still rendering at display resolution (unlike QLabel, which renders to a pixmap once and then resizes that), and unlike QSvgWidget, this supports changing the position of the SVG within the widget.

Note that animation is not currently supported.