### PR TITLE
Fix combobox delegate popup

### DIFF
--- a/itemviews/qtComboBoxDelegate.h
+++ b/itemviews/qtComboBoxDelegate.h
@@ -12,21 +12,23 @@ class QTE_EXPORT qtComboBoxDelegate : public qtAbstractListDelegate
   Q_OBJECT
 
 public:
-  qtComboBoxDelegate(QObject* parent = 0);
-  virtual ~qtComboBoxDelegate();
+    qtComboBoxDelegate(QObject* parent = nullptr);
+    virtual ~qtComboBoxDelegate();
 
-  virtual void setModelData(QWidget* editor, QAbstractItemModel*,
-                            const QModelIndex&) const;
+    virtual void setModelData(
+        QWidget* editor, QAbstractItemModel* model,
+        QModelIndex const& index) const override;
 
-  virtual void updateEditorGeometry(QWidget* editor,
-                                    const QStyleOptionViewItem&,
-                                    const QModelIndex&) const;
+    virtual void updateEditorGeometry(
+        QWidget* editor, QStyleOptionViewItem const& opt,
+        QModelIndex const& index) const override;
 
 protected:
   using qtAbstractListDelegate::setModelData;
 
-  virtual QWidget* createListEditor(QWidget* parent) const;
-  virtual void setListEditorData(QWidget* editor, const QVariant&) const;
+  virtual QWidget* createListEditor(QWidget* parent) const override;
+  virtual void setListEditorData(
+      QWidget* editor, QVariant const& newData) const override;
 
 private:
   QTE_DISABLE_COPY(qtComboBoxDelegate);


### PR DESCRIPTION
See commit log for details. Short version: fix a bug where the popup would be shown and immediately hidden due to how `QComboBox` handles mouse events.