### PR TITLE
Fix some warnings related to code in need of modernization

### DIFF
--- a/core/qtCliArgs.cpp
+++ b/core/qtCliArgs.cpp
@@ -682,19 +682,19 @@ void qtCliArgs::usageError(const QString& message) const
 bool qtCliArgs::isSet(const QString& name) const
 {
   QTE_D_CONST(qtCliArgs);
-  qtCliOption* option = d->optionMap.value(name, 0);
+  qtCliOption* option = d->optionMap.value(name, nullptr);
   if (option)
     {
     return option->isSet();
     }
   else if (name.length() > 4 && name.startsWith("no-"))
     {
-    qtCliOption* option = d->optionMap.value(name.mid(3), 0);
+    qtCliOption* option = d->optionMap.value(name.mid(3), nullptr);
     return (option ? !option->isSet() : false);
     }
   else
     {
-    qtCliOption* option = d->optionMap.value("no-" + name, 0);
+    qtCliOption* option = d->optionMap.value("no-" + name, nullptr);
     return (option ? !option->isSet() : false);
     }
 }
@@ -703,7 +703,7 @@ bool qtCliArgs::isSet(const QString& name) const
 QString qtCliArgs::value(const QString& name) const
 {
   QTE_D_CONST(qtCliArgs);
-  qtCliOption* option = d->optionMap.value(name, 0);
+  qtCliOption* option = d->optionMap.value(name, nullptr);
   return (option ? option->value() : QString());
 }
 
@@ -711,7 +711,7 @@ QString qtCliArgs::value(const QString& name) const
 QStringList qtCliArgs::values(const QString& name) const
 {
   QTE_D_CONST(qtCliArgs);
-  qtCliOption* option = d->optionMap.value(name, 0);
+  qtCliOption* option = d->optionMap.value(name, nullptr);
   return (option ? option->values() : QStringList());
 }
 
@@ -764,7 +764,7 @@ char** qtCliArgs::qtArgv()
   // Build new mutable argv vector
   int k = d->qtArgs.count();
   char** argv = new char*[k + 1];
-  argv[k] = 0;
+  argv[k] = nullptr;
   while (k--)
     {
     QByteArray arg = d->qtArgs[k].toLocal8Bit();

--- a/core/qtCliArgs.cpp
+++ b/core/qtCliArgs.cpp
@@ -519,7 +519,7 @@ bool qtCliArgs::parse(ParseOptions options)
 //-----------------------------------------------------------------------------
 void qtCliArgs::parseOrDie(int exitCode)
 {
-  this->parseOrDie(static_cast<ParseOptions>(0), exitCode);
+  this->parseOrDie({}, exitCode);
 }
 
 //-----------------------------------------------------------------------------

--- a/core/qtCliArgs.h
+++ b/core/qtCliArgs.h
@@ -26,7 +26,7 @@ public:
   qtCliArgs(int argc, char** argv);
   ~qtCliArgs();
 
-  void addOptions(const qtCliOptions&, QString group = QString(),
+  void addOptions(const qtCliOptions&, QString group = {},
                   bool includeWithCommon = true);
   void addNamedArguments(const qtCliOptions&);
 
@@ -37,7 +37,7 @@ public:
 
   void parseError() const;
   void shortUsage() const;
-  void usage(QString group = QString()) const;
+  void usage(QString group = {}) const;
   void usageError(const QString& message) const;
 
   bool isSet(const QString& name) const;

--- a/core/qtCliArgs.h
+++ b/core/qtCliArgs.h
@@ -30,7 +30,7 @@ public:
                   bool includeWithCommon = true);
   void addNamedArguments(const qtCliOptions&);
 
-  bool parse(ParseOptions = static_cast<qtCliArgs::ParseOptions>(0));
+  bool parse(ParseOptions = {});
   void parseOrDie(int exitCode = 1);
   void parseOrDie(ParseOption, int exitCode = 1);
   void parseOrDie(ParseOptions, int exitCode = 1);

--- a/core/qtCliOption.h
+++ b/core/qtCliOption.h
@@ -32,8 +32,8 @@ public:
 
   qtCliOption& add(const QString& name, Flags);
   qtCliOption& add(const QString& name, const QString& description, Flags);
-  qtCliOption& add(QString name, QString description = QString(),
-                   QString defaultValue = QString(), Flags = {});
+  qtCliOption& add(QString name, QString description = {},
+                   QString defaultValue = {}, Flags = {});
 
   QString preferredName() const;
   QStringList shortNames() const;

--- a/core/qtCliOption.h
+++ b/core/qtCliOption.h
@@ -33,8 +33,7 @@ public:
   qtCliOption& add(const QString& name, Flags);
   qtCliOption& add(const QString& name, const QString& description, Flags);
   qtCliOption& add(QString name, QString description = QString(),
-                   QString defaultValue = QString(),
-                   Flags = static_cast<qtCliOption::Flags>(0));
+                   QString defaultValue = QString(), Flags = {});
 
   QString preferredName() const;
   QStringList shortNames() const;

--- a/core/qtCliOptions.h
+++ b/core/qtCliOptions.h
@@ -24,8 +24,8 @@ public:
   qtCliOption& add(const QString& name, qtCliOption::Flags);
   qtCliOption& add(const QString& name, const QString& description,
                    qtCliOption::Flags);
-  qtCliOption& add(const QString& name, QString description = QString(),
-                   QString defaultValue = QString(), qtCliOption::Flags = {});
+  qtCliOption& add(const QString& name, QString description = {},
+                   QString defaultValue = {}, qtCliOption::Flags = {});
 
   bool isEmpty() const;
   QList<qtCliOption> options() const;

--- a/core/qtCliOptions.h
+++ b/core/qtCliOptions.h
@@ -25,7 +25,7 @@ public:
   qtCliOption& add(const QString& name, const QString& description,
                    qtCliOption::Flags);
   qtCliOption& add(const QString& name, QString description = QString(),
-                   QString defaultValue = QString(), qtCliOption::Flags = 0);
+                   QString defaultValue = QString(), qtCliOption::Flags = {});
 
   bool isEmpty() const;
   QList<qtCliOption> options() const;

--- a/core/qtDebug.cpp
+++ b/core/qtDebug.cpp
@@ -8,7 +8,7 @@
 
 #undef qtDebug
 
-const qtDebugAreaAccessor qtDebug::InvalidArea = 0;
+const qtDebugAreaAccessor qtDebug::InvalidArea = nullptr;
 
 //-----------------------------------------------------------------------------
 class qtDebugAreaPrivate

--- a/core/qtTest.cpp
+++ b/core/qtTest.cpp
@@ -24,7 +24,7 @@ static void qtMessageHandler(
     static QThreadStorage<qtTest::StreamPointer*> ts;
     qtTest::StreamPointer* tsp = ts.localData();
 
-    if (stream || msg == 0)
+    if (stream || msg == nullptr)
     {
         if (tsp)
             (*tsp) = stream;
@@ -155,7 +155,7 @@ uint qtTest::pushMessageStream(qtTest::StreamPointer stream)
     QTE_D();
 
     // Register new stream with handler
-    qtMessageHandler(QtSystemMsg, 0, stream);
+    qtMessageHandler(QtSystemMsg, nullptr, stream);
 
     // Add stream to stack
     uint token = static_cast<uint>(d->streamStack.count());
@@ -176,7 +176,7 @@ void qtTest::popMessageStream(uint token)
     StreamPointer stream;
     if (d->streamStack.count())
         stream = d->streamStack.top();
-    qtMessageHandler(QtSystemMsg, 0, stream);
+    qtMessageHandler(QtSystemMsg, nullptr, stream);
 }
 
 //-----------------------------------------------------------------------------

--- a/core/qtTest.h
+++ b/core/qtTest.h
@@ -40,17 +40,17 @@ public:
 
     inline int test(
         bool exprValue, QString const& exprText, int line = 0,
-        char const* file = 0, char const* func = 0);
+        char const* file = nullptr, char const* func = nullptr);
     template <typename T>
     inline int testEqual(
         T expectedValue, T actualValue, QString const& exprText,
-        int line = 0, char const* file = 0, char const* func = 0);
+        int line = 0, char const* file = nullptr, char const* func = nullptr);
     int testEqual(
         float expectedValue, float actualValue, QString const& exprText,
-        int line = 0, char const* file = 0, char const* func = 0);
+        int line = 0, char const* file = nullptr, char const* func = nullptr);
     int testEqual(
         double expectedValue, double actualValue, QString const& exprText,
-        int line = 0, char const* file = 0, char const* func = 0);
+        int line = 0, char const* file = nullptr, char const* func = nullptr);
 
     int testResult() const;
     int setTestResult(int);
@@ -76,8 +76,8 @@ private:
 class QTE_EXPORT qtTestTrace
 {
 public:
-    qtTestTrace(qtTest& test, int line = 0, char const* file = 0,
-                char const* func = 0);
+    qtTestTrace(qtTest& test, int line = 0, char const* file = nullptr,
+                char const* func = nullptr);
     ~qtTestTrace();
 
 protected:

--- a/core/qtUtil.h
+++ b/core/qtUtil.h
@@ -76,10 +76,11 @@ namespace qtUtil
   /// "standard" icons for okay, cancel, etc. rather than the system icons.
   QTE_EXPORT void setStandardIcons(QDialogButtonBox*);
 
-  QTE_EXPORT void setApplicationIcon(const QString& name, QMainWindow* = 0);
+  QTE_EXPORT void setApplicationIcon(
+    const QString& name, QMainWindow* = nullptr);
 
-  QTE_EXPORT void resizeColumnsToContents(QTreeWidget*,
-                                          bool includeCollapsedItems = true);
+  QTE_EXPORT void resizeColumnsToContents(
+    QTreeWidget*, bool includeCollapsedItems = true);
 
   /// Make widget transparent.
   ///

--- a/designer/qtCloseButtonInterface.h
+++ b/designer/qtCloseButtonInterface.h
@@ -16,7 +16,7 @@ class qtCloseButtonInterface
     Q_INTERFACES(QDesignerCustomWidgetInterface)
 
 public:
-    qtCloseButtonInterface(QObject* parent = 0)
+    qtCloseButtonInterface(QObject* parent = nullptr)
         : qtDesignerWidgetInterfaceHelper<qtCloseButton>(parent)
     {
     }

--- a/designer/qtColorButtonInterface.h
+++ b/designer/qtColorButtonInterface.h
@@ -16,7 +16,7 @@ class qtColorButtonInterface
     Q_INTERFACES(QDesignerCustomWidgetInterface)
 
 public:
-    qtColorButtonInterface(QObject* parent = 0)
+    qtColorButtonInterface(QObject* parent = nullptr)
         : qtDesignerWidgetInterfaceHelper<qtColorButton>(parent)
     {
     }

--- a/designer/qtDesignerPlugin.h
+++ b/designer/qtDesignerPlugin.h
@@ -21,7 +21,7 @@ class qtDesignerPlugin : public QObject,
 
 public:
     typedef QList<QDesignerCustomWidgetInterface*> InterfaceList;
-    qtDesignerPlugin(QObject* parent = 0);
+    qtDesignerPlugin(QObject* parent = nullptr);
 
     virtual InterfaceList customWidgets() const QTE_OVERRIDE;
 

--- a/designer/qtDesignerWidgetInterface.h
+++ b/designer/qtDesignerWidgetInterface.h
@@ -17,7 +17,7 @@ class qtDesignerWidgetInterface : public QObject,
     Q_INTERFACES(QDesignerCustomWidgetInterface)
 
 public:
-    qtDesignerWidgetInterface(QObject* parent = 0);
+    qtDesignerWidgetInterface(QObject* parent = nullptr);
 
     virtual bool isInitialized() const QTE_OVERRIDE;
 

--- a/designer/qtDoubleSliderInterface.h
+++ b/designer/qtDoubleSliderInterface.h
@@ -16,7 +16,7 @@ class qtDoubleSliderInterface
     Q_INTERFACES(QDesignerCustomWidgetInterface)
 
 public:
-    qtDoubleSliderInterface(QObject* parent = 0)
+    qtDoubleSliderInterface(QObject* parent = nullptr)
         : qtDesignerWidgetInterfaceHelper<qtDoubleSlider>(parent)
     {
     }

--- a/designer/qtExpanderInterface.h
+++ b/designer/qtExpanderInterface.h
@@ -16,7 +16,7 @@ class qtExpanderInterface
     Q_INTERFACES(QDesignerCustomWidgetInterface)
 
 public:
-    qtExpanderInterface(QObject* parent = 0)
+    qtExpanderInterface(QObject* parent = nullptr)
         : qtDesignerWidgetInterfaceHelper<qtExpander>(parent)
     {
     }

--- a/designer/qtOverlayWidgetInterface.h
+++ b/designer/qtOverlayWidgetInterface.h
@@ -16,7 +16,7 @@ class qtOverlayWidgetInterface
     Q_INTERFACES(QDesignerCustomWidgetInterface)
 
 public:
-    qtOverlayWidgetInterface(QObject* parent = 0)
+    qtOverlayWidgetInterface(QObject* parent = nullptr)
         : qtDesignerWidgetInterfaceHelper<qtOverlayWidget>(parent)
     {
     }

--- a/designer/qtProgressWidgetInterface.h
+++ b/designer/qtProgressWidgetInterface.h
@@ -16,7 +16,7 @@ class qtProgressWidgetInterface :
     Q_INTERFACES(QDesignerCustomWidgetInterface)
 
 public:
-    qtProgressWidgetInterface(QObject* parent = 0)
+    qtProgressWidgetInterface(QObject* parent = nullptr)
         : qtDesignerWidgetInterfaceHelper<qtProgressWidget>(parent)
     {
     }

--- a/designer/qtSqueezedLabelInterface.h
+++ b/designer/qtSqueezedLabelInterface.h
@@ -16,7 +16,7 @@ class qtSqueezedLabelInterface
     Q_INTERFACES(QDesignerCustomWidgetInterface)
 
 public:
-    qtSqueezedLabelInterface(QObject* parent = 0)
+    qtSqueezedLabelInterface(QObject* parent = nullptr)
         : qtDesignerWidgetInterfaceHelper<qtSqueezedLabel>(parent)
     {
     }

--- a/designer/qtSvgWidgetInterface.h
+++ b/designer/qtSvgWidgetInterface.h
@@ -16,7 +16,7 @@ class qtSvgWidgetInterface
     Q_INTERFACES(QDesignerCustomWidgetInterface)
 
 public:
-    qtSvgWidgetInterface(QObject* parent = 0)
+    qtSvgWidgetInterface(QObject* parent = nullptr)
         : qtDesignerWidgetInterfaceHelper<qtSvgWidget>(parent)
     {
     }

--- a/designer/qtThrobberInterface.h
+++ b/designer/qtThrobberInterface.h
@@ -16,7 +16,7 @@ class qtThrobberInterface
     Q_INTERFACES(QDesignerCustomWidgetInterface)
 
 public:
-    qtThrobberInterface(QObject* parent = 0)
+    qtThrobberInterface(QObject* parent = nullptr)
         : qtDesignerWidgetInterfaceHelper<qtThrobber>(parent)
     {
     }

--- a/dialogs/qtActionManagerDialog.h
+++ b/dialogs/qtActionManagerDialog.h
@@ -17,7 +17,8 @@ class QTE_EXPORT qtActionManagerDialog : public QDialog
   Q_OBJECT
 
 public:
-  qtActionManagerDialog(QWidget* parent = 0, Qt::WindowFlags flags = {});
+  qtActionManagerDialog(QWidget* parent = nullptr,
+                        Qt::WindowFlags flags = {});
   virtual ~qtActionManagerDialog();
 
 protected slots:

--- a/dialogs/qtActionManagerDialog.h
+++ b/dialogs/qtActionManagerDialog.h
@@ -17,7 +17,7 @@ class QTE_EXPORT qtActionManagerDialog : public QDialog
   Q_OBJECT
 
 public:
-  qtActionManagerDialog(QWidget* parent = 0, Qt::WindowFlags flags = 0);
+  qtActionManagerDialog(QWidget* parent = 0, Qt::WindowFlags flags = {});
   virtual ~qtActionManagerDialog();
 
 protected slots:

--- a/dialogs/qtActionManagerDialog.h
+++ b/dialogs/qtActionManagerDialog.h
@@ -21,7 +21,7 @@ public:
   virtual ~qtActionManagerDialog();
 
 protected slots:
-  void filterChanged(QString text = QString());
+  void filterChanged(QString text = {});
 
 protected:
   QTE_DECLARE_PRIVATE_PTR(qtActionManagerDialog)

--- a/dialogs/qtConfirmationDialog.cpp
+++ b/dialogs/qtConfirmationDialog.cpp
@@ -39,8 +39,10 @@ qtConfirmationDialog::qtConfirmationDialog(
 
   // Set dialog icon
   QStyle* style = this->style();
-  int iconSize = style->pixelMetric(QStyle::PM_MessageBoxIconSize, 0, this);
-  QIcon icon = style->standardIcon(QStyle::SP_MessageBoxWarning, 0, this);
+  int iconSize =
+    style->pixelMetric(QStyle::PM_MessageBoxIconSize, nullptr, this);
+  QIcon icon =
+    style->standardIcon(QStyle::SP_MessageBoxWarning, nullptr, this);
   QPixmap pixmap = icon.pixmap(iconSize, iconSize);
   d->UI.image->setPixmap(pixmap);
   d->UI.image->setFixedSize(pixmap.size());

--- a/dialogs/qtConfirmationDialog.h
+++ b/dialogs/qtConfirmationDialog.h
@@ -23,8 +23,8 @@ public:
     UserCanChoose
     };
 
-  qtConfirmationDialog(
-    const QString& askKey, QWidget* parent = 0, Qt::WindowFlags flags = {});
+  qtConfirmationDialog(const QString& askKey, QWidget* parent = nullptr,
+                       Qt::WindowFlags flags = {});
   virtual ~qtConfirmationDialog();
 
   void setPrompt(const QString&);

--- a/dialogs/qtConfirmationDialog.h
+++ b/dialogs/qtConfirmationDialog.h
@@ -24,7 +24,7 @@ public:
     };
 
   qtConfirmationDialog(
-    const QString& askKey, QWidget* parent = 0, Qt::WindowFlags flags = 0);
+    const QString& askKey, QWidget* parent = 0, Qt::WindowFlags flags = {});
   virtual ~qtConfirmationDialog();
 
   void setPrompt(const QString&);
@@ -39,11 +39,11 @@ public:
   static bool getConfirmation(
     QWidget* parent, const QString& askKey, const QString& prompt,
     const QString& confirmText, AskPreferenceScope scope,
-    QString title = QString(), Qt::WindowFlags flags = 0);
+    QString title = QString(), Qt::WindowFlags flags = {});
   static bool getConfirmation(
     QWidget* parent, const QString& askKey, const QString& prompt,
     QString title = QString(), QString confirmText = QString(),
-    AskPreferenceScope scope = UserCanChoose, Qt::WindowFlags flags = 0);
+    AskPreferenceScope scope = UserCanChoose, Qt::WindowFlags flags = {});
 
   static bool willAsk(const QString& key);
   static void setAsk(const QString& key, bool ask, bool persistent);

--- a/dialogs/qtConfirmationDialog.h
+++ b/dialogs/qtConfirmationDialog.h
@@ -39,10 +39,10 @@ public:
   static bool getConfirmation(
     QWidget* parent, const QString& askKey, const QString& prompt,
     const QString& confirmText, AskPreferenceScope scope,
-    QString title = QString(), Qt::WindowFlags flags = {});
+    QString title = {}, Qt::WindowFlags flags = {});
   static bool getConfirmation(
     QWidget* parent, const QString& askKey, const QString& prompt,
-    QString title = QString(), QString confirmText = QString(),
+    QString title = {}, QString confirmText = {},
     AskPreferenceScope scope = UserCanChoose, Qt::WindowFlags flags = {});
 
   static bool willAsk(const QString& key);

--- a/dialogs/qtDoubleInputDialog.h
+++ b/dialogs/qtDoubleInputDialog.h
@@ -20,18 +20,18 @@ class QTE_EXPORT qtDoubleInputDialog : protected QDialog
 public:
   static double getDouble(
     QWidget* parent, const QString& title, const QString& label, double value,
-    double minValue, double maxValue, bool* okay = 0,
+    double minValue, double maxValue, bool* okay = nullptr,
     Qt::WindowFlags flags = {});
 
   static double getDouble(
     QWidget* parent, const QString& title, const QString& label, double value,
     double minValue, double maxValue, int decimals = 1, double step = 1.0,
-    bool* okay = 0, Qt::WindowFlags flags = {});
+    bool* okay = nullptr, Qt::WindowFlags flags = {});
 
   static double getDouble(
     QWidget* parent, const QString& title, const QString& label, double value,
     double minValue, double maxValue, const QString& specialValueText,
-    int decimals = 1, double step = 1.0, bool* okay = 0,
+    int decimals = 1, double step = 1.0, bool* okay = nullptr,
     Qt::WindowFlags flags = {});
 
 protected:

--- a/dialogs/qtDoubleInputDialog.h
+++ b/dialogs/qtDoubleInputDialog.h
@@ -21,18 +21,18 @@ public:
   static double getDouble(
     QWidget* parent, const QString& title, const QString& label, double value,
     double minValue, double maxValue, bool* okay = 0,
-    Qt::WindowFlags flags = 0);
+    Qt::WindowFlags flags = {});
 
   static double getDouble(
     QWidget* parent, const QString& title, const QString& label, double value,
     double minValue, double maxValue, int decimals = 1, double step = 1.0,
-    bool* okay = 0, Qt::WindowFlags flags = 0);
+    bool* okay = 0, Qt::WindowFlags flags = {});
 
   static double getDouble(
     QWidget* parent, const QString& title, const QString& label, double value,
     double minValue, double maxValue, const QString& specialValueText,
     int decimals = 1, double step = 1.0, bool* okay = 0,
-    Qt::WindowFlags flags = 0);
+    Qt::WindowFlags flags = {});
 
 protected:
   QTE_DECLARE_PRIVATE_PTR(qtDoubleInputDialog)

--- a/dialogs/qtGradientEditor.h
+++ b/dialogs/qtGradientEditor.h
@@ -18,7 +18,7 @@ class QTE_EXPORT qtGradientEditor : public QDialog
     Q_OBJECT
 
 public:
-    qtGradientEditor(QWidget* parent = 0, Qt::WindowFlags flags = 0);
+    qtGradientEditor(QWidget* parent = 0, Qt::WindowFlags flags = {});
     virtual ~qtGradientEditor();
 
     qtGradient gradient() const;

--- a/dialogs/qtGradientEditor.h
+++ b/dialogs/qtGradientEditor.h
@@ -18,7 +18,7 @@ class QTE_EXPORT qtGradientEditor : public QDialog
     Q_OBJECT
 
 public:
-    qtGradientEditor(QWidget* parent = 0, Qt::WindowFlags flags = {});
+    qtGradientEditor(QWidget* parent = nullptr, Qt::WindowFlags flags = {});
     virtual ~qtGradientEditor();
 
     qtGradient gradient() const;

--- a/dom/qtDom.cpp
+++ b/dom/qtDom.cpp
@@ -50,7 +50,7 @@ QList<QDomElement> findElements(
 QList<QDomElement> findElements(const QDomNode& root,
                                 const QString& selector)
 {
-  const QStringList selectors = selector.split(' ', QString::SkipEmptyParts);
+  const QStringList selectors = selector.split(' ', Qt::SkipEmptyParts);
   QList<QDomElement> result;
   return findElements(result, root, selectors);
 }

--- a/dom/qtDomElement.h
+++ b/dom/qtDomElement.h
@@ -85,7 +85,7 @@ public:
   /// element's "id" attribute is set to \p id.
   explicit qtDomElement(QDomDocument& doc,
                         const QString& tagName,
-                        const QString& id = QString());
+                        const QString& id = {});
 
   /// Construct a qtDomElement from a QDomElement.
   ///

--- a/io/qtKstReader.cpp
+++ b/io/qtKstReader.cpp
@@ -457,7 +457,7 @@ QRegExp qtKstReader::defaultTerminator()
 }
 
 //-----------------------------------------------------------------------------
-qtKstReader::qtKstReader() : d_ptr(0)
+qtKstReader::qtKstReader() : d_ptr{nullptr}
 {
 }
 

--- a/itemviews/qtAbstractListDelegate.h
+++ b/itemviews/qtAbstractListDelegate.h
@@ -16,7 +16,7 @@ class QTE_EXPORT qtAbstractListDelegate : public QStyledItemDelegate
   Q_OBJECT
 
 public:
-  qtAbstractListDelegate(QObject* parent = 0);
+  qtAbstractListDelegate(QObject* parent = nullptr);
   virtual ~qtAbstractListDelegate();
 
   virtual QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem&,

--- a/itemviews/qtAbstractListDelegate.h
+++ b/itemviews/qtAbstractListDelegate.h
@@ -34,7 +34,7 @@ protected:
   virtual QWidget* createListEditor(QWidget* parent) const = 0;
   virtual void setListEditorData(QWidget* editor, const QVariant&) const = 0;
 
-  void setMapping(QStringList names, QVariantList values = QVariantList());
+  void setMapping(QStringList names, QVariantList values = {});
   QStringList valueNames() const;
   QVariant valueData(const QString&) const;
 

--- a/itemviews/qtDoubleSpinBoxDelegate.h
+++ b/itemviews/qtDoubleSpinBoxDelegate.h
@@ -16,7 +16,7 @@ class QTE_EXPORT qtDoubleSpinBoxDelegate : public QStyledItemDelegate
   Q_OBJECT
 
 public:
-  qtDoubleSpinBoxDelegate(QObject* parent = 0);
+  qtDoubleSpinBoxDelegate(QObject* parent = nullptr);
   virtual ~qtDoubleSpinBoxDelegate();
 
   void setRange(double minimum, double maximum);

--- a/itemviews/qtListDelegate.h
+++ b/itemviews/qtListDelegate.h
@@ -14,7 +14,7 @@ class QTE_EXPORT qtListDelegate : public qtAbstractListDelegate
   Q_OBJECT
 
 public:
-  qtListDelegate(QObject* parent = 0);
+  qtListDelegate(QObject* parent = nullptr);
   virtual ~qtListDelegate();
 
   virtual void setModelData(QWidget* editor, QAbstractItemModel*,

--- a/itemviews/qtRichTextDelegate.h
+++ b/itemviews/qtRichTextDelegate.h
@@ -14,7 +14,7 @@ class QTE_EXPORT qtRichTextDelegate : public QStyledItemDelegate
   Q_OBJECT
 
 public:
-  qtRichTextDelegate(QObject* parent = 0);
+  qtRichTextDelegate(QObject* parent = nullptr);
   virtual ~qtRichTextDelegate();
 
 protected:

--- a/itemviews/qtSpinBoxDelegate.h
+++ b/itemviews/qtSpinBoxDelegate.h
@@ -16,7 +16,7 @@ class QTE_EXPORT qtSpinBoxDelegate : public QStyledItemDelegate
   Q_OBJECT
 
 public:
-  qtSpinBoxDelegate(QObject* parent = 0);
+  qtSpinBoxDelegate(QObject* parent = nullptr);
   virtual ~qtSpinBoxDelegate();
 
   void setDataRole(Qt::ItemDataRole);

--- a/tests/TestConfirmationDialog.cpp
+++ b/tests/TestConfirmationDialog.cpp
@@ -21,7 +21,7 @@ int main(int argc, char** argv)
     " confirmation; that is because the setting key is blank.\n\nWhen you"
     " select a button, the dialog will go away and the test will end. There"
     " will be no persistent effect either way.";
-  qtConfirmationDialog::getConfirmation(0, "Test", prompt);
+  qtConfirmationDialog::getConfirmation(nullptr, "Test", prompt);
 
   return 0;
 }

--- a/tests/TestDoubleSlider.h
+++ b/tests/TestDoubleSlider.h
@@ -12,7 +12,7 @@ class TestDoubleSliderWidget : public QWidget
   Q_OBJECT
 
 public:
-  explicit TestDoubleSliderWidget(QWidget* parent = 0);
+  explicit TestDoubleSliderWidget(QWidget* parent = nullptr);
   ~TestDoubleSliderWidget() {}
 
 protected slots:

--- a/tests/TestDrawers.h
+++ b/tests/TestDrawers.h
@@ -18,7 +18,7 @@ class TestDrawersWidget : public QWidget
   Q_OBJECT
 
 public:
-  TestDrawersWidget(QWidget* parent = 0);
+  TestDrawersWidget(QWidget* parent = nullptr);
   virtual ~TestDrawersWidget();
 
 public slots:

--- a/tests/TestExpander.h
+++ b/tests/TestExpander.h
@@ -19,7 +19,7 @@ class TestExpanderWidget : public QWidget
   Q_OBJECT
 
 public:
-  TestExpanderWidget(QWidget* parent = 0);
+  TestExpanderWidget(QWidget* parent = nullptr);
   virtual ~TestExpanderWidget() {}
 
 public slots:

--- a/tests/TestSqueezedLabel.cpp
+++ b/tests/TestSqueezedLabel.cpp
@@ -56,7 +56,7 @@ TestSqueezedLabelWidget::TestSqueezedLabelWidget(QWidget* parent)
 //-----------------------------------------------------------------------------
 void TestSqueezedLabelWidget::setElideMode()
 {
-  qtSqueezedLabel::ElideMode mode = 0;
+  auto mode = qtSqueezedLabel::ElideMode{};
 //   if (this->elideStart->isChecked())
 //     mode |= qtSqueezedLabel::ElideStart;
   if (this->elideEnd->isChecked())

--- a/tests/TestSqueezedLabel.h
+++ b/tests/TestSqueezedLabel.h
@@ -20,7 +20,7 @@ class TestSqueezedLabelWidget : public QWidget
   Q_OBJECT
 
 public:
-  TestSqueezedLabelWidget(QWidget* parent = 0);
+  TestSqueezedLabelWidget(QWidget* parent = nullptr);
   virtual ~TestSqueezedLabelWidget() {}
 
 public slots:

--- a/tests/TestUiState.cpp
+++ b/tests/TestUiState.cpp
@@ -321,7 +321,7 @@ int main(int argc, char* argv[])
   QApplication app(argc, argv); // Needed to construct widgets
   qtTest t_obj;
 
-  qsrand(static_cast<uint>(time(0)));
+  qsrand(static_cast<uint>(time(nullptr)));
 
   t_obj.runSuite("Custom Mapping Test", testCustomItem);
   t_obj.runSuite("Built-in Mapping Tests", testBuiltin);

--- a/tests/qtEditableLabel.h
+++ b/tests/qtEditableLabel.h
@@ -16,7 +16,7 @@ class qtEditableLabel : public QLabel
   Q_OBJECT
 
 public:
-  qtEditableLabel(QWidget* parent = 0);
+  qtEditableLabel(QWidget* parent = nullptr);
   virtual ~qtEditableLabel();
 
 public slots:

--- a/tools/qtActionManagerCompiler.cpp
+++ b/tools/qtActionManagerCompiler.cpp
@@ -28,7 +28,7 @@ typedef QHash<QString, ObjectProperties> ActionMap;
 typedef QMultiHash<QString, QString> ActionGroupMap;
 
 //-----------------------------------------------------------------------------
-QDebug out(QtMsgType type = QtDebugMsg, QString file = QString(),
+QDebug out(QtMsgType type = QtDebugMsg, QString file = {},
            uint line = 0, uint col = 0)
 {
   QString prefix = "qte-amc:";
@@ -53,13 +53,13 @@ QDebug out(QtMsgType type = QtDebugMsg, QString file = QString(),
 }
 
 //-----------------------------------------------------------------------------
-QDebug err(QString file = QString(), uint line = 0, uint col = 0)
+QDebug err(QString file = {}, uint line = 0, uint col = 0)
 {
   return out(QtCriticalMsg, file, line, col) << "error:";
 }
 
 //-----------------------------------------------------------------------------
-QDebug warn(QString file = QString(), uint line = 0, uint col = 0)
+QDebug warn(QString file = {}, uint line = 0, uint col = 0)
 {
   return out(QtWarningMsg, file, line, col) << "warning:";
 }

--- a/util/qtAbstractAnimation.h
+++ b/util/qtAbstractAnimation.h
@@ -23,7 +23,7 @@ class QTE_EXPORT qtAbstractAnimation : public QObject
   Q_PROPERTY(double duration READ duration)
 
 public:
-  qtAbstractAnimation(QObject* parent = 0);
+  qtAbstractAnimation(QObject* parent = nullptr);
   virtual ~qtAbstractAnimation();
 
   QAbstractAnimation::State state() const;

--- a/util/qtActionFactory.h
+++ b/util/qtActionFactory.h
@@ -17,9 +17,10 @@ class qtActionManagerDialog;
 class QTE_EXPORT qtActionFactory
 {
 public:
-  QAction* createAction(QObject* parent, QActionGroup* group = 0) const;
-  QAction* createAction(QSettings&, QObject* parent,
-                        QActionGroup* group = 0) const;
+  QAction* createAction(
+    QObject* parent, QActionGroup* group = nullptr) const;
+  QAction* createAction(
+    QSettings&, QObject* parent, QActionGroup* group = nullptr) const;
 
   void setShortcutContext(Qt::ShortcutContext);
   void setCheckable(bool);

--- a/util/qtActionManager.cpp
+++ b/util/qtActionManager.cpp
@@ -30,7 +30,7 @@ public:
 //-----------------------------------------------------------------------------
 qtActionManager* qtActionManager::instance()
 {
-  static qtActionManager* theInstance = 0;
+  static qtActionManager* theInstance = nullptr;
 
   // Create global instance, if it doesn't exist. The global QCoreApplication
   // instance must be created first, as we parent ourselves to it so that it
@@ -83,7 +83,7 @@ qtActionFactory* qtActionManager::registerAction(
 {
   if (settingsKey.isEmpty())
     {
-    return 0;
+    return nullptr;
     }
 
   if (displayGroup.isEmpty())

--- a/util/qtActionManager.h
+++ b/util/qtActionManager.h
@@ -25,15 +25,14 @@ public:
   virtual ~qtActionManager();
 
   qtActionFactory* registerAction(
-    QString settingsKey, QString text,
-    QString displayGroup = QString(), QString icon = QString(),
-    QKeySequence defaultShortcut = QKeySequence());
+    QString settingsKey, QString text, QString displayGroup = {},
+    QString icon = {}, QKeySequence defaultShortcut = {});
   qtActionFactory* registerAction(
     QString settingsKey, QString text, QString displayGroup, QString icon,
     QList<QKeySequence> defaultShortcuts);
 
   void setupAction(QSettings& settings, QAction* action, QString settingsKey,
-                   QString icon = QString());
+                   QString icon = {});
 
 protected slots:
   void unregisterStaticAction(QObject*);

--- a/util/qtActionPriorityList.cpp
+++ b/util/qtActionPriorityList.cpp
@@ -50,7 +50,7 @@ QAction* qtActionPriorityList::insertAction(QAction* action, int priority)
   QTE_D_MUTABLE(qtActionPriorityList);
 
   const qtActionPriorityListData::iterator iter = ++d->insert(priority, action);
-  return (iter == d->end() ? 0 : iter.value());
+  return (iter == d->end() ? nullptr : iter.value());
 }
 
 //-----------------------------------------------------------------------------
@@ -59,5 +59,5 @@ QAction* qtActionPriorityList::followingAction(int priority) const
   QTE_D_SHARED(qtActionPriorityList);
 
   const qtActionPriorityListData::const_iterator iter = d->lowerBound(priority);
-  return (iter == d->constEnd() ? 0 : iter.value());
+  return (iter == d->constEnd() ? nullptr : iter.value());
 }

--- a/util/qtActionPriorityList.h
+++ b/util/qtActionPriorityList.h
@@ -29,7 +29,7 @@ public:
   ///
   /// \param followingAction Pointer to an action which will follow (come
   ///                        after) actions inserted into this list.
-  qtActionPriorityList(QAction* followingAction = 0);
+  qtActionPriorityList(QAction* followingAction = nullptr);
 
   /// Copy constructor.
   qtActionPriorityList(const qtActionPriorityList&);

--- a/util/qtPrioritizedMenuProxy.h
+++ b/util/qtPrioritizedMenuProxy.h
@@ -38,7 +38,7 @@ public:
   ///   Flags specifying if and where separators should be added to the menu
   ///   when actions are inserted via the proxy.
   qtPrioritizedMenuProxy(
-    QMenu* menu, QAction* followingAction = 0,
+    QMenu* menu, QAction* followingAction = nullptr,
     qtUtil::SeparatorBehavior separators = qtUtil::NoSeparators);
 
   ~qtPrioritizedMenuProxy();

--- a/util/qtPrioritizedToolBarProxy.h
+++ b/util/qtPrioritizedToolBarProxy.h
@@ -40,7 +40,7 @@ public:
   ///   Flags specifying if and where separators should be added to the menu
   ///   when actions are inserted via the proxy.
   qtPrioritizedToolBarProxy(
-    QToolBar* toolBar, QAction* followingAction = 0,
+    QToolBar* toolBar, QAction* followingAction = nullptr,
     qtUtil::SeparatorBehavior separators = qtUtil::NoSeparators);
 
   ~qtPrioritizedToolBarProxy();

--- a/util/qtSettings.h
+++ b/util/qtSettings.h
@@ -43,8 +43,7 @@ public:
 protected:
   QTE_DECLARE_PRIVATE_PTR(qtSettings)
 
-  void declareSetting(const QString& key,
-                      const QVariant& defaultValue = QVariant(),
+  void declareSetting(const QString& key, const QVariant& defaultValue = {},
                       Scope = DefaultScope);
   void declareSetting(const QString& key, qtAbstractSetting*);
   QVariant value(const QString& key) const;

--- a/util/qtStatusManager.h
+++ b/util/qtStatusManager.h
@@ -36,7 +36,7 @@ public:
   void transferOwnership(const QObject* from, qtStatusSource to);
 
 public slots:
-  void setStatusText(qtStatusSource source, QString text = QString());
+  void setStatusText(qtStatusSource source, QString text = {});
   void setProgress(qtStatusSource source, bool available = false,
                    qreal value = -1);
   void setProgress(qtStatusSource source, bool available, int value,

--- a/util/qtStatusManager.h
+++ b/util/qtStatusManager.h
@@ -22,7 +22,7 @@ class QTE_EXPORT qtStatusManager : public QObject
   Q_OBJECT
 
 public:
-  explicit qtStatusManager(QObject* parent = 0);
+  explicit qtStatusManager(QObject* parent = nullptr);
   ~qtStatusManager();
 
   void addStatusLabel(QLabel*);

--- a/util/qtStatusNotifier.h
+++ b/util/qtStatusNotifier.h
@@ -24,7 +24,7 @@ public:
   void addReceiver(qtStatusManager*) const;
 
 signals:
-  void statusMessageAvailable(qtStatusSource, QString = QString());
+  void statusMessageAvailable(qtStatusSource, QString = {});
   void progressAvailable(qtStatusSource, bool = false, qreal value = -1);
   void progressAvailable(qtStatusSource, bool, int value, int steps);
 

--- a/util/qtStatusSource.h
+++ b/util/qtStatusSource.h
@@ -17,7 +17,7 @@ class qtStatusSourcePrivate;
 class QTE_EXPORT qtStatusSource
 {
 public:
-  /*implicit*/ qtStatusSource(QObject* = 0);
+  /*implicit*/ qtStatusSource(QObject* = nullptr);
   qtStatusSource(const qtStatusSource& other);
 
   ~qtStatusSource();

--- a/util/qtUiState.cpp
+++ b/util/qtUiState.cpp
@@ -112,7 +112,7 @@ void qtUiStatePrivate::save(const QStringList& keys) const
 {
   foreach (auto const& key, keys)
     {
-    qtUiState::AbstractItem* item = this->items.value(key, 0);
+    qtUiState::AbstractItem* item = this->items.value(key, nullptr);
     if (item)
       {
       this->store->setValue(key, item->value());
@@ -129,7 +129,7 @@ void qtUiStatePrivate::restore(const QStringList& keys) const
 
   foreach (auto const& key, keys)
     {
-    qtUiState::AbstractItem* item = this->items.value(key, 0);
+    qtUiState::AbstractItem* item = this->items.value(key, nullptr);
     if (item)
       {
       item->setValue(this->store->value(key, item->value()));
@@ -173,8 +173,8 @@ template <typename O>
 qtUiStatePrivate::StateItem<O>::StateItem(
   O* object, ReadMethod read, WriteMethod write)
   : object(object), version(0),
-    read(read), readVersioned(0),
-    write(write), writeVersioned(0)
+    read(read), readVersioned(nullptr),
+    write(write), writeVersioned(nullptr)
 {
 }
 
@@ -183,8 +183,8 @@ template <typename O>
 qtUiStatePrivate::StateItem<O>::StateItem(
   O* object, ReadVersionedMethod read, WriteVersionedMethod write, int version)
   : object(object), version(version),
-    read(0), readVersioned(read),
-    write(0), writeVersioned(write)
+    read(nullptr), readVersioned(read),
+    write(nullptr), writeVersioned(write)
 {
 }
 

--- a/util/qtUiState.h
+++ b/util/qtUiState.h
@@ -100,7 +100,7 @@ public:
   /// If \p store is non-null, the qtUiState takes ownership of the QSettings
   /// object and uses it to save and restore the UI state. Otherwise, qtUiState
   /// uses a default-constructed QSettings.
-  explicit qtUiState(QSettings* store = 0);
+  explicit qtUiState(QSettings* store = nullptr);
 
   virtual ~qtUiState();
 

--- a/util/qtUiStateItem.h
+++ b/util/qtUiStateItem.h
@@ -70,7 +70,7 @@ protected:
 template <typename T, typename O>
 qtUiState::Item<T, O>::Item(
     O* object, ReadMethod read, WriteRefMethod write)
-    : object(object), read(read), writeRef(write), writeVal(0)
+    : object(object), read(read), writeRef(write), writeVal(nullptr)
 {
 }
 
@@ -78,7 +78,7 @@ qtUiState::Item<T, O>::Item(
 template <typename T, typename O>
 qtUiState::Item<T, O>::Item(
     O* object, ReadMethod read, WriteValMethod write)
-    : object(object), read(read), writeRef(0), writeVal(write)
+    : object(object), read(read), writeRef(nullptr), writeVal(write)
 {
 }
 

--- a/widgets/qtCloseButton.h
+++ b/widgets/qtCloseButton.h
@@ -19,7 +19,7 @@ class QTE_EXPORT qtCloseButton : public QToolButton
                WRITE setVisibleWhenDisabled)
 
 public:
-    qtCloseButton(QWidget* parent = 0);
+    qtCloseButton(QWidget* parent = nullptr);
     ~qtCloseButton();
 
     QSize sizeHint() const override;

--- a/widgets/qtColorButton.h
+++ b/widgets/qtColorButton.h
@@ -19,7 +19,7 @@ class QTE_EXPORT qtColorButton : public QPushButton
   Q_PROPERTY(bool alphaShown READ isAlphaShown WRITE setAlphaShown)
 
 public:
-  qtColorButton(QWidget* parent = 0);
+  qtColorButton(QWidget* parent = nullptr);
   virtual ~qtColorButton();
 
   virtual QSize minimumSizeHint() const QTE_OVERRIDE;

--- a/widgets/qtDoubleSlider.h
+++ b/widgets/qtDoubleSlider.h
@@ -35,7 +35,7 @@ public:
     QuantizeAbsolute
     };
 
-  explicit qtDoubleSlider(QWidget* parent = 0);
+  explicit qtDoubleSlider(QWidget* parent = nullptr);
   virtual ~qtDoubleSlider();
 
   double minimum() const;

--- a/widgets/qtDrawer.cpp
+++ b/widgets/qtDrawer.cpp
@@ -52,10 +52,10 @@ private:
 
 //-----------------------------------------------------------------------------
 qtDrawerPrivate::qtDrawerPrivate(qtDrawer* q)
-  : q_ptr(q), expander(0), expanded(false),
+  : q_ptr(q), expander(nullptr), expanded(false),
     expanderPolicy(qtDrawer::ExpanderAsNeeded),
-    container(0), containerLayout(0), parent(0),
-    indentLayout(0), row(-1), indent(-1),
+    container(nullptr), containerLayout(nullptr), parent(nullptr),
+    indentLayout(nullptr), row(-1), indent(-1),
     visibilityFlag(true)
 {
 }
@@ -69,7 +69,7 @@ void qtDrawerPrivate::setExpander(bool shouldExist, bool shouldEnable)
       {
       // Remove expander
       delete this->expander;
-      this->expander = 0;
+      this->expander = nullptr;
       }
     else
       {

--- a/widgets/qtDrawer.h
+++ b/widgets/qtDrawer.h
@@ -27,7 +27,7 @@ public:
     ExpanderAlwaysShown = 1
     };
 
-  explicit qtDrawer(qtDrawer* parent, qtDrawer* nextSibling = 0);
+  explicit qtDrawer(qtDrawer* parent, qtDrawer* nextSibling = nullptr);
   virtual ~qtDrawer();
 
   qtDrawer* parent();
@@ -51,13 +51,13 @@ protected:
 
   qtDrawer(qtDrawerWidget* container, QGridLayout* layout);
 
-  virtual void addChild(qtDrawer* child, qtDrawer* before = 0);
+  virtual void addChild(qtDrawer* child, qtDrawer* before = nullptr);
   virtual void removeChild(qtDrawer* child);
-  void setChildVisibility(qtDrawer* child = 0);
+  void setChildVisibility(qtDrawer* child = nullptr);
 
   int countDescendants() const;
-  void shiftChildrenDown(qtDrawer* afterChild = 0);
-  void shiftChildrenUp(qtDrawer* afterChild = 0);
+  void shiftChildrenDown(qtDrawer* afterChild = nullptr);
+  void shiftChildrenUp(qtDrawer* afterChild = nullptr);
   void shiftDown();
   void shiftUp();
   void shift();

--- a/widgets/qtDrawerWidget.cpp
+++ b/widgets/qtDrawerWidget.cpp
@@ -13,7 +13,7 @@ QTE_IMPLEMENT_D_FUNC(qtDrawerWidget)
 class qtDrawerWidgetPrivate
 {
 public:
-  qtDrawerWidgetPrivate() : root(0) {}
+  qtDrawerWidgetPrivate() : root{nullptr} {}
 
   qtDrawer* root;
 };

--- a/widgets/qtDrawerWidget.h
+++ b/widgets/qtDrawerWidget.h
@@ -17,10 +17,10 @@ class QTE_EXPORT qtDrawerWidget : public QWidget
   Q_OBJECT
 
 public:
-  qtDrawerWidget(QWidget* parent = 0);
+  qtDrawerWidget(QWidget* parent = nullptr);
   virtual ~qtDrawerWidget();
 
-  virtual qtDrawer* addDrawer(qtDrawer* nextSibling = 0);
+  virtual qtDrawer* addDrawer(qtDrawer* nextSibling = nullptr);
   virtual void clear();
 
 protected:

--- a/widgets/qtExpander.h
+++ b/widgets/qtExpander.h
@@ -14,8 +14,8 @@ class QTE_EXPORT qtExpander : public QToolButton
   Q_OBJECT
 
 public:
-  qtExpander(QWidget* parent = 0);
-  qtExpander(bool initiallyExpanded, QWidget* parent = 0);
+  qtExpander(QWidget* parent = nullptr);
+  qtExpander(bool initiallyExpanded, QWidget* parent = nullptr);
 
   QSize sizeHint() const;
   QSize minimumSizeHint() const;

--- a/widgets/qtExpander.h
+++ b/widgets/qtExpander.h
@@ -21,9 +21,7 @@ public:
   QSize minimumSizeHint() const;
   using QWidget::size;
 
-  static QSize size(QStyle* style,
-                    QString text = QString(),
-                    QFont font = QFont());
+  static QSize size(QStyle* style, QString text = {}, QFont font = {});
 
 protected:
   static QSize arrowSize();

--- a/widgets/qtGradientWidget.h
+++ b/widgets/qtGradientWidget.h
@@ -21,7 +21,7 @@ class QTE_EXPORT qtGradientWidget : public QWidget
   Q_PROPERTY(Qt::Orientation orientation READ orientation WRITE setOrientation)
 
 public:
-  qtGradientWidget(QWidget* parent = 0);
+  qtGradientWidget(QWidget* parent = nullptr);
   virtual ~qtGradientWidget();
 
   Qt::Orientation orientation() const;

--- a/widgets/qtMenu.h
+++ b/widgets/qtMenu.h
@@ -20,7 +20,7 @@ class QTE_EXPORT qtMenu : public QMenu
     Q_OBJECT
 
 public:
-    qtMenu(QWidget* parent = 0);
+    qtMenu(QWidget* parent = nullptr);
     virtual ~qtMenu();
 
 protected:

--- a/widgets/qtOverlayWidget.h
+++ b/widgets/qtOverlayWidget.h
@@ -14,7 +14,7 @@ class QTE_EXPORT qtOverlayWidget : public QStackedWidget
   Q_OBJECT
 
 public:
-  qtOverlayWidget(QWidget* parent = 0);
+  qtOverlayWidget(QWidget* parent = nullptr);
   virtual ~qtOverlayWidget();
 
 private:

--- a/widgets/qtSqueezedLabel.h
+++ b/widgets/qtSqueezedLabel.h
@@ -46,9 +46,9 @@ public:
     };
     Q_DECLARE_FLAGS(SetToolTipMode, SetToolTipFlag)
 
-    qtSqueezedLabel(QWidget* parent = nullptr, Qt::WindowFlags = 0);
+    qtSqueezedLabel(QWidget* parent = nullptr, Qt::WindowFlags = {});
     qtSqueezedLabel(QString const& text, QWidget* parent = nullptr,
-                    Qt::WindowFlags = 0);
+                    Qt::WindowFlags = {});
     virtual ~qtSqueezedLabel();
 
     ElideMode elideMode() const;

--- a/widgets/qtSvgWidget.h
+++ b/widgets/qtSvgWidget.h
@@ -21,9 +21,9 @@ class QTE_EXPORT qtSvgWidget : public QWidget
                READ hasScaledContents WRITE setScaledContents)
 
 public:
-    qtSvgWidget(QWidget* parent = nullptr, Qt::WindowFlags = 0);
+    qtSvgWidget(QWidget* parent = nullptr, Qt::WindowFlags = {});
     qtSvgWidget(QString const& resource, QWidget* parent = nullptr,
-                Qt::WindowFlags = 0);
+                Qt::WindowFlags = {});
     virtual ~qtSvgWidget();
 
     QString resource() const;

--- a/widgets/qtThrobber.h
+++ b/widgets/qtThrobber.h
@@ -30,7 +30,7 @@ public:
     };
     Q_ENUM(Style)
 
-    qtThrobber(QWidget* parent = 0);
+    qtThrobber(QWidget* parent = nullptr);
     virtual ~qtThrobber();
 
     QSize minimumSizeHint() const;


### PR DESCRIPTION
Fix some warnings about use of deprecated code constructs, particularly `QFlags` being initialized with `0`. While we're at it, fix all use of `0` that ought to be `nullptr` these days and replace argument default values of the form `Type()` with `{}`.

The first in particular should fix a warning that can otherwise pop up for our consumers.