### PR TITLE
Add function to set icon theme

### DIFF
--- a/core/qtUtil.cpp
+++ b/core/qtUtil.cpp
@@ -21,172 +21,165 @@ namespace qtUtil
 {
 
 //-----------------------------------------------------------------------------
-bool localeLess(const QString& a, const QString& b)
+bool localeLess(QString const& a, QString const& b)
 {
-  return a.localeAwareCompare(b) < 0;
+    return a.localeAwareCompare(b) < 0;
 }
 
 //-----------------------------------------------------------------------------
-QStringList localeSort(const QStringList& list)
+QStringList localeSort(QStringList const& list)
 {
-  QStringList result = list;
-  std::sort(result.begin(), result.end(), &localeLess);
-  return result;
+    auto result = list;
+    std::sort(result.begin(), result.end(), &localeLess);
+    return result;
 }
 
 //-----------------------------------------------------------------------------
-QString standardIconResource(const QString& name, int size)
+QString standardIconResource(QString const& name, int size)
 {
-  return QString(":icons/%1x%1/%2").arg(size).arg(name);
+    return QString(":icons/%1x%1/%2").arg(size).arg(name);
 }
 
 //-----------------------------------------------------------------------------
-QIcon standardIcon(const QString& name, int size)
+QIcon standardIcon(QString const& name, int size)
 {
-  return QIcon{standardIconResource(name, size)};
+    return QIcon{standardIconResource(name, size)};
 }
 
 //-----------------------------------------------------------------------------
-QIcon standardIcon(const QString& name, QList<int> sizes)
+QIcon standardIcon(QString const& name, QList<int> sizes)
 {
-  QIcon icon;
-  foreach (auto const size, sizes)
-    icon.addFile(standardIconResource(name, size));
-  return icon;
+    QIcon icon;
+    foreach (auto const size, sizes)
+        icon.addFile(standardIconResource(name, size));
+    return icon;
 }
 
 //-----------------------------------------------------------------------------
-QIcon standardActionIcon(const QString& name)
+QIcon standardActionIcon(QString const& name)
 {
-  QIcon icon(standardIconResource(name, 16));
-  icon.addFile(standardIconResource(name, 22));
-  icon.addFile(standardIconResource(name, 24));
-  icon.addFile(standardIconResource(name, 32));
-  return icon;
+    auto icon = QIcon{standardIconResource(name, 16)};
+    icon.addFile(standardIconResource(name, 22));
+    icon.addFile(standardIconResource(name, 24));
+    icon.addFile(standardIconResource(name, 32));
+    return icon;
 }
 
 //-----------------------------------------------------------------------------
-QIcon standardApplicationIcon(const QString& name)
+QIcon standardApplicationIcon(QString const& name)
 {
-  QIcon icon(standardIconResource(name, 16));
-  icon.addFile(standardIconResource(name, 32));
-  icon.addFile(standardIconResource(name, 48));
-  icon.addFile(standardIconResource(name, 64));
-  icon.addFile(standardIconResource(name, 128));
-  return icon;
+    auto icon = QIcon{standardIconResource(name, 16)};
+    icon.addFile(standardIconResource(name, 32));
+    icon.addFile(standardIconResource(name, 48));
+    icon.addFile(standardIconResource(name, 64));
+    icon.addFile(standardIconResource(name, 128));
+    return icon;
 }
 
 //-----------------------------------------------------------------------------
 void setStandardIcon(
-  QDialogButtonBox* buttons,
-  QDialogButtonBox::StandardButton which,
-  QString name)
+    QDialogButtonBox* buttons,
+    QDialogButtonBox::StandardButton which,
+    QString name)
 {
-  if (buttons->button(which))
+    if (buttons->button(which))
     {
-    QIcon icon = standardActionIcon(name);
-    if (icon.availableSizes().count())
-      {
-      buttons->button(which)->setIcon(icon);
-      }
+        QIcon icon = standardActionIcon(name);
+        if (icon.availableSizes().count())
+            buttons->button(which)->setIcon(icon);
     }
 }
 
 //-----------------------------------------------------------------------------
 void setStandardIcons(QDialogButtonBox* buttons)
 {
-  setStandardIcon(buttons, QDialogButtonBox::Ok, "okay");
-  setStandardIcon(buttons, QDialogButtonBox::Cancel, "cancel");
-  setStandardIcon(buttons, QDialogButtonBox::Apply, "apply");
-  setStandardIcon(buttons, QDialogButtonBox::Reset, "reset");
-  setStandardIcon(buttons, QDialogButtonBox::RestoreDefaults, "reset");
-  setStandardIcon(buttons, QDialogButtonBox::Close, "close");
+    setStandardIcon(buttons, QDialogButtonBox::Ok, "okay");
+    setStandardIcon(buttons, QDialogButtonBox::Cancel, "cancel");
+    setStandardIcon(buttons, QDialogButtonBox::Apply, "apply");
+    setStandardIcon(buttons, QDialogButtonBox::Reset, "reset");
+    setStandardIcon(buttons, QDialogButtonBox::RestoreDefaults, "reset");
+    setStandardIcon(buttons, QDialogButtonBox::Close, "close");
 }
 
 //-----------------------------------------------------------------------------
-void setApplicationIcon(const QString& name, QMainWindow* mainWindow)
+void setApplicationIcon(QString const& name, QMainWindow* mainWindow)
 {
-  const QIcon icon = standardApplicationIcon(name);
-  qApp->setWindowIcon(icon);
-  mainWindow && (mainWindow->setWindowIcon(icon), false);
+    auto const& icon = standardApplicationIcon(name);
+    qApp->setWindowIcon(icon);
+    if (mainWindow)
+        mainWindow->setWindowIcon(icon);
 }
 
 //-----------------------------------------------------------------------------
 void resizeColumnsToContents(QTreeWidget* tree, bool includeCollapsedItems)
 {
-  QList<QTreeWidgetItem*> collapsedItems;
+    auto collapsedItems = QList<QTreeWidgetItem*>{};
 
-  // If including collapsed items, first expand the entire tree
-  if (includeCollapsedItems)
+    // If including collapsed items, first expand the entire tree
+    if (includeCollapsedItems)
     {
-    for (QTreeWidgetItemIterator iter(tree); *iter; ++iter)
-      {
-      QTreeWidgetItem* item = *iter;
-      if (item->childCount() && !item->isExpanded())
+        for (QTreeWidgetItemIterator iter(tree); *iter; ++iter)
         {
-        item->setExpanded(true);
-        collapsedItems.append(item);
+            auto* const item = *iter;
+            if (item->childCount() && !item->isExpanded())
+            {
+                item->setExpanded(true);
+                collapsedItems.append(item);
+            }
         }
-      }
     }
 
-  int i = tree->columnCount();
-  while (i--)
+    auto i = tree->columnCount();
+    while (i--)
     {
-    // Resize to data
-    tree->resizeColumnToContents(i);
+        // Resize to data
+        tree->resizeColumnToContents(i);
 
-    // Also resize to header, if applicable
-    if (!tree->isHeaderHidden())
-      {
-      // Get current size
-      int cw = tree->columnWidth(i);
-
-      // Get header text and icon
-      QString text = tree->headerItem()->text(i);
-      QIcon icon = tree->headerItem()->icon(i);
-
-      // Get header font, using widget font if unset
-      QFont font = tree->font();
-      QVariant hfd = tree->headerItem()->data(i, Qt::FontRole);
-      if (hfd.isValid() && hfd.canConvert(QVariant::Font))
+        // Also resize to header, if applicable
+        if (!tree->isHeaderHidden())
         {
-        font = hfd.value<QFont>();
-        }
+            // Get current size
+            auto const cw = tree->columnWidth(i);
 
-      // Calculate size of text and icon
-      QFontMetrics fm(font);
-      int tw = fm.boundingRect(text).width();
-      if (!icon.isNull())
-        {
-        tw += icon.actualSize(tree->iconSize()).width();
-        }
+            // Get header text and icon
+            auto const& text = tree->headerItem()->text(i);
+            auto const& icon = tree->headerItem()->icon(i);
 
-      // Add space for margins and sort indicator
-      tw += 2 * tree->style()->pixelMetric(QStyle::PM_HeaderMargin);
-      tw += 2 * tree->style()->pixelMetric(QStyle::PM_HeaderGripMargin);
-      tw += tree->style()->pixelMetric(QStyle::PM_HeaderMarkSize);
+            // Get header font, using widget font if unset
+            auto font = tree->font();
+            auto hfd = tree->headerItem()->data(i, Qt::FontRole);
+            if (hfd.isValid() && hfd.canConvert(QVariant::Font))
+                font = hfd.value<QFont>();
 
-      // Use header size, if larger
-      if (tw > cw)
-        {
-        tree->setColumnWidth(i, tw);
+            // Calculate size of text and icon
+            auto fm = QFontMetrics{font};
+            auto tw = fm.boundingRect(text).width();
+            if (!icon.isNull())
+                tw += icon.actualSize(tree->iconSize()).width();
+
+            // Add space for margins and sort indicator
+            tw += 2 * tree->style()->pixelMetric(QStyle::PM_HeaderMargin);
+            tw += 2 * tree->style()->pixelMetric(QStyle::PM_HeaderGripMargin);
+            tw += tree->style()->pixelMetric(QStyle::PM_HeaderMarkSize);
+
+            // Use header size, if larger
+            if (tw > cw)
+                tree->setColumnWidth(i, tw);
         }
-      }
     }
 
-  // Restore collapsed state of anything we expanded
-  foreach (auto const item, collapsedItems)
-    item->setExpanded(false);
+    // Restore collapsed state of anything we expanded
+    foreach (auto const item, collapsedItems)
+        item->setExpanded(false);
 }
 
 //-----------------------------------------------------------------------------
 void makeTransparent(QWidget* widget)
 {
-  QPalette::ColorRole cr = widget->backgroundRole();
-  QPalette palette = widget->palette();
-  palette.setBrush(cr, QBrush());
-  widget->setPalette(palette);
+    auto const cr = widget->backgroundRole();
+    auto palette = widget->palette();
+    palette.setBrush(cr, QBrush{});
+    widget->setPalette(palette);
 }
 
 } // namespace qtUtil

--- a/core/qtUtil.h
+++ b/core/qtUtil.h
@@ -79,6 +79,14 @@ namespace qtUtil
     QTE_EXPORT void setApplicationIcon(
         QString const& name, QMainWindow* = nullptr);
 
+    /// Set application icon theme.
+    ///
+    /// This function changes the name of the application icon theme, which is
+    /// typically done when the application supplies its own theme. Unlike
+    /// QIcon::setThemeName, this function also preserves the existing (system)
+    /// theme as a fallback, when possible (Qt 5.12 or later).
+    QTE_EXPORT void setIconTheme(QString const& themeName);
+
     QTE_EXPORT void resizeColumnsToContents(
         QTreeWidget*, bool includeCollapsedItems = true);
 

--- a/core/qtUtil.h
+++ b/core/qtUtil.h
@@ -19,77 +19,77 @@ template <typename T> class QList;
 
 namespace qtUtil
 {
-  /// Sort a list of strings in a locale-aware manner.
-  ///
-  /// This function sorts a ::QStringList using QString::localeAwareCompare as
-  /// the comparison function.
-  QTE_EXPORT QStringList localeSort(const QStringList&);
+    /// Sort a list of strings in a locale-aware manner.
+    ///
+    /// This function sorts a ::QStringList using QString::localeAwareCompare
+    /// as the comparison function.
+    QTE_EXPORT QStringList localeSort(QStringList const&);
 
-  /// Retrieve icon resource by name.
-  ///
-  /// This function retrieves an icon from an applications resource pool based
-  /// on the icon's short name, assuming that the resource name follows the
-  /// standard template ':icons/<i>size</i>x<i>size</i>/<i>name</i>. The
-  /// returned icon has a single pixmap matching the requested size.
-  ///
-  /// \param name Short name of the icon to retrieve.
-  /// \param size Size to retrieve.
-  QTE_EXPORT QIcon standardIcon(const QString& name, int size);
+    /// Retrieve icon resource by name.
+    ///
+    /// This function retrieves an icon from an applications resource pool
+    /// based on the icon's short name, assuming that the resource name follows
+    /// the standard template ':icons/<i>size</i>x<i>size</i>/<i>name</i>. The
+    /// returned icon has a single pixmap matching the requested size.
+    ///
+    /// \param name Short name of the icon to retrieve.
+    /// \param size Size to retrieve.
+    QTE_EXPORT QIcon standardIcon(QString const& name, int size);
 
-  /// Retrieve icon resource by name.
-  ///
-  /// This function retrieves an icon from an applications resource pool based
-  /// on the icon's short name. It will attempt to load multiple pixmaps for
-  /// the icon matching the list of requested sizes.
-  ///
-  /// \param name Short name of the icon to retrieve.
-  /// \param sizes List of sizes to retrieve.
-  QTE_EXPORT QIcon standardIcon(const QString& name, QList<int> sizes);
+    /// Retrieve icon resource by name.
+    ///
+    /// This function retrieves an icon from an applications resource pool
+    /// based on the icon's short name. It will attempt to load multiple
+    /// pixmaps for the icon matching the list of requested sizes.
+    ///
+    /// \param name Short name of the icon to retrieve.
+    /// \param sizes List of sizes to retrieve.
+    QTE_EXPORT QIcon standardIcon(QString const& name, QList<int> sizes);
 
-  /// Retrieve action icon resource by name.
-  ///
-  /// This function retrieves an icon from an applications resource pool based
-  /// on the icon's short name, automatically loading multiple pixmaps for
-  /// standard action icon resolutions.
-  ///
-  /// \param name Short name of the icon to retrieve.
-  ///
-  /// \sa qtUtil::standardIcon
-  QTE_EXPORT QIcon standardActionIcon(const QString& name);
+    /// Retrieve action icon resource by name.
+    ///
+    /// This function retrieves an icon from an applications resource pool based
+    /// on the icon's short name, automatically loading multiple pixmaps for
+    /// standard action icon resolutions.
+    ///
+    /// \param name Short name of the icon to retrieve.
+    ///
+    /// \sa qtUtil::standardIcon
+    QTE_EXPORT QIcon standardActionIcon(QString const& name);
 
-  /// Retrieve application icon resource by name.
-  ///
-  /// This function retrieves an icon from an applications resource pool based
-  /// on the icon's short name, automatically loading multiple pixmaps for
-  /// standard application icon resolutions.
-  ///
-  /// \param name Short name of the icon to retrieve.
-  ///
-  /// \sa qtUtil::standardIcon
-  QTE_EXPORT QIcon standardApplicationIcon(const QString& name);
+    /// Retrieve application icon resource by name.
+    ///
+    /// This function retrieves an icon from an applications resource pool
+    /// based on the icon's short name, automatically loading multiple pixmaps
+    /// for standard application icon resolutions.
+    ///
+    /// \param name Short name of the icon to retrieve.
+    ///
+    /// \sa qtUtil::standardIcon
+    QTE_EXPORT QIcon standardApplicationIcon(QString const& name);
 
-  /// Apply "standard" action icons to dialog buttons.
-  ///
-  /// This function applies the "standard" icons (as returned by
-  /// standardActionIcon) to the standard buttons of a QDialogButtonBox. This
-  /// provides greater consistency for applications that use their own
-  /// "standard" icons for okay, cancel, etc. rather than the system icons.
-  QTE_EXPORT void setStandardIcons(QDialogButtonBox*);
+    /// Apply "standard" action icons to dialog buttons.
+    ///
+    /// This function applies the "standard" icons (as returned by
+    /// standardActionIcon) to the standard buttons of a QDialogButtonBox.
+    /// This provides greater consistency for applications that use their own
+    /// "standard" icons for okay, cancel, etc. rather than the system icons.
+    QTE_EXPORT void setStandardIcons(QDialogButtonBox*);
 
-  QTE_EXPORT void setApplicationIcon(
-    const QString& name, QMainWindow* = nullptr);
+    QTE_EXPORT void setApplicationIcon(
+        QString const& name, QMainWindow* = nullptr);
 
-  QTE_EXPORT void resizeColumnsToContents(
-    QTreeWidget*, bool includeCollapsedItems = true);
+    QTE_EXPORT void resizeColumnsToContents(
+        QTreeWidget*, bool includeCollapsedItems = true);
 
-  /// Make widget transparent.
-  ///
-  /// This function makes a widget "transparent" by setting the background
-  /// brush used to paint the widget's background (as determined by
-  /// QWidget::backgroundRole()) to a default-constructed (transparent) brush.
-  /// For most widgets, this will result in the widget not painting a
-  /// background, making it effectively transparent.
-  QTE_EXPORT void makeTransparent(QWidget*);
+    /// Make widget transparent.
+    ///
+    /// This function makes a widget "transparent" by setting the background
+    /// brush used to paint the widget's background (as determined by
+    /// QWidget::backgroundRole()) to a default-constructed (transparent)
+    /// brush. For most widgets, this will result in the widget not painting a
+    /// background, making it effectively transparent.
+    QTE_EXPORT void makeTransparent(QWidget*);
 }
 
 #endif


### PR DESCRIPTION
Update style for `qtUtil`. Create a new function in qtUtil to set the icon theme.

See documentation thereof for rationale. Additionally, due to an apparent Qt bug, getting the name of the system theme requires a nasty work-around that involves asking GTK(!), which makes it much more unreasonable for individual applications to have to do this themselves.