### PR TITLE
Fix build for Qt < 5.12

### DIFF
--- a/dom/qtDom.cpp
+++ b/dom/qtDom.cpp
@@ -50,7 +50,11 @@ QList<QDomElement> findElements(
 QList<QDomElement> findElements(const QDomNode& root,
                                 const QString& selector)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
   const QStringList selectors = selector.split(' ', Qt::SkipEmptyParts);
+#else
+  const QStringList selectors = selector.split(' ', QString::SkipEmptyParts);
+#endif
   QList<QDomElement> result;
   return findElements(result, root, selectors);
 }

--- a/tests/TestNaturalSort.cpp
+++ b/tests/TestNaturalSort.cpp
@@ -16,8 +16,9 @@ using namespace qtNaturalSort;
 static auto const& special5 = QString::fromUtf8(u8"\xf0\x9d\x9f\xbb");
 
 //-----------------------------------------------------------------------------
-struct ExpectedStringGroup
+class ExpectedStringGroup
 {
+public:
     ExpectedStringGroup() = default;
     ExpectedStringGroup(ExpectedStringGroup const&) = default;
 
@@ -38,13 +39,16 @@ struct ExpectedStringGroup
                significantDigits == other.significantDigits;
     }
 
-    QString const characters;
-    int const leadingZeros = 0;
-    int const significantDigits = 0;
+protected:
+    friend QDebug& operator<<(QDebug&, ExpectedStringGroup const&);
+
+    QString characters;
+    int leadingZeros = 0;
+    int significantDigits = 0;
 };
 
 //-----------------------------------------------------------------------------
-QDebug& operator<<(QDebug& dbg, ExpectedStringGroup g)
+QDebug& operator<<(QDebug& dbg, ExpectedStringGroup const& g)
 {
   dbg << '{' << g.characters;
   if (g.significantDigits || g.leadingZeros)

--- a/util/qtColorScheme.cpp
+++ b/util/qtColorScheme.cpp
@@ -27,7 +27,9 @@ void qtColorScheme::load(QPalette::ColorGroup group, const QString& groupName,
 {
   this->load(group, groupName, ARGS(Base), settings);
   this->load(group, groupName, ARGS(Text), settings);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
   this->load(group, groupName, ARGS(PlaceholderText), settings);
+#endif
   this->load(group, groupName, ARGS(AlternateBase), settings);
   this->load(group, groupName, ARGS(Window), settings);
   this->load(group, groupName, ARGS(WindowText), settings);
@@ -73,7 +75,9 @@ void qtColorScheme::save(QPalette::ColorGroup group, const QString& groupName,
 {
   this->save(group, groupName, ARGS(Base), settings);
   this->save(group, groupName, ARGS(Text), settings);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
   this->save(group, groupName, ARGS(PlaceholderText), settings);
+#endif
   this->save(group, groupName, ARGS(AlternateBase), settings);
   this->save(group, groupName, ARGS(Window), settings);
   this->save(group, groupName, ARGS(WindowText), settings);


### PR DESCRIPTION
Fix qtColorScheme for Qt < 5.12. *Do* use deprecated QString::split, as the new signature doesn't exist until Qt 5.14.